### PR TITLE
Add wikidata ids

### DIFF
--- a/import/wikipedia/requirements.txt
+++ b/import/wikipedia/requirements.txt
@@ -1,0 +1,3 @@
+pandas
+requests
+tqmd

--- a/import/wikipedia/wikidata.csv
+++ b/import/wikipedia/wikidata.csv
@@ -1,0 +1,4230 @@
+country,partyfacts_id,wikidata_id,name,name_short,name_native
+AFG,6641,Q3360918,Afghan Social Democratic Party,,
+AFG,8280,Q6971563,National Coalition of Afghanistan,,Etelaf-e Milli
+AFG,6642,Q3083533,Islamic Movement of Afghanistan,,حرکت اسلامی افغانستان
+AFG,8867,Q5722596,Truth and Justice Party,,
+AFG,6643,Q948574,Hezbe Islami,,د افغانستان اسلامي حزب
+AFG,8610,Q3366678,Republican Party of Afghanistan,,
+AFG,8233,Q18379591,National Revolutionary Party of Afghanistan,,حزب انقلاب ملی
+AFG,5876,Q3135114,Hezbe Wahdat,,
+AFG,8611,Q7165584,People's Islamic Unity Party of Afghanistan,,حزب وحدت اسلامی مردم افغانستان
+AFG,8282,Q840809,Islamic Dawah Organisation of Afghanistan,,
+AFG,5183,Q1261999,Jamiat-e Islami,,
+AFG,6644,Q3189989,National Islamic Movement of Afghanistan,,
+AFG,5881,Q6972799,National Front,,
+AFG,5184,Q1186355,People’s Democratic Party of Afghanistan,PDPA,د افغانستان د خلق دموکراټیک ګوند
+AFG,8700,Q7248734,Progressive Democratic Party of Afghanistan,,
+ALB,8354,Q2576740,Red and Black Alliance,,Aleanca Kuq e Zi
+ALB,8377,Q689339,Balli Kombëtar,,Balli Kombëtar
+ALB,717,Q3025840,Liberal Democratic Union,,Bashkimi Liberal Demokrat
+ALB,6396,Q1881141,Democratic Front of Albania,,
+ALB,3697,Q7006952,New Democratic Spirit,,Fryma e Re Demokratike
+ALB,2297,Q1123814,Socialist Movement for Integration,LSI,Lëvizja Socialiste për Integrim
+ALB,8491,Q28225030,Libra Party,LIBRA,Lista e Barabartë
+ALB,840,Q396033,Environmentalist Agrarian Party,,Partia Agrare Ambientaliste
+ALB,594,Q1186135,Democratic Alliance Party,,Partia Aleanca Demokratike
+ALB,674,Q3088514,Albanian National Front Party,PBK,Partia Balli Kombëtar Shqiptar
+ALB,1636,Q1788029,Unity for Human Rights Party,,
+ALB,1558,Q3181716,New Democratic Party,,Partia Demokrate e Re
+ALB,190,Q845743,Democratic Party of Albania,PD,Partia Demokratike e Shqipërisë
+ALB,7013,Q1078268,Christian Democratic Party of Albania,,Partia Demokristiane e Shqipërisë
+ALB,3270,Q3301730,"Party for Justice, Integration and Unity",PDIU,"Partia Drejtësi, Integrim dhe Unitet"
+ALB,4711,Q161395,Party of Labour of Albania,,Partia e Punës e Shqipërisë
+ALB,8378,Q1465719,Albanian Fascist Party,,Partia Fashiste Shqiptare
+ALB,4715,Q16830869,Christian Democratic Party of Albania,,Partia Kristian Demokrate e Shqipërisë
+ALB,732,Q719839,Legality Movement Party,,Partia Lëvizja e Legalitetit
+ALB,819,Q1838820,Republican Party of Albania,,Partia Republikane e Shqipërisë
+ALB,838,Q1533055,Social Democratic Party of Albania,PSD,Partia Socialdemokrate e Shqipërisë
+ALB,1729,Q642882,Socialist Party of Albania,PS,Partia Socialiste e Shqipërisë
+DZA,8564,Q2838049,Green Algeria Alliance,,Alliance de l'Algérie verte
+DZA,4111,Q204543,National Liberation Front,FLN,جبهة التحرير الوطني
+DZA,4114,Q605960,Socialist Forces Front,,Front des Forces socialistes
+DZA,6118,Q734545,Islamic Salvation Front,,الجبهة الإسلامية للإنقاذ
+DZA,4098,Q912180,Algerian National Front,,الجبهة الوطنية الجزائرية
+DZA,6219,Q1790632,Islamic Renaissance Movement,,
+DZA,5221,Q1889454,Movement of Society for Peace,MSP,حركة مجتمع السلم
+DZA,5222,Q852320,Movement for National Reform,,
+DZA,5622,Q627196,Workers' Party,,
+DZA,8868,Q3366402,Party of Algerian Renewal,,
+DZA,4113,Q840321,Democratic National Rally,,التجمع الوطني الديمقراطي‎
+DZA,6120,Q1627773,Rally for Culture and Democracy,,
+DZA,8734,Q97189639,Rally for Hope for Algeria,,
+AND,4207,Q6972221,National Democratic Group,AND,
+AND,3712,Q2662810,Andorra for Change,APC,Andorra pel Canvi
+AND,4900,Q6970351,National Andorran Coalition,CNA,
+AND,3713,Q24863,Democrats for Andorra,DA,Demòcrates per Andorra
+AND,6433,Q7139360,Parochial Union of Independents Group,,Grup d'Unió Parroquial Independents
+AND,3711,Q5255661,Democratic National Initiative,IDN,
+AND,6516,Q1567803,New Centre,,Nou Centre
+AND,3710,Q16932904,New Democracy,ND,
+AND,4208,Q5255677,Democratic Party,PD,Partit Demòcrata
+AND,3675,Q24866,Social Democratic Party,PS,Partit Socialdemòcrata
+AND,3674,Q3775933,Democratic Renewal,RD,Renovació Democràtica
+AND,5875,Q19843090,Social Democracy and Progress,SDP,Socialdemocràcia i Progrés
+AND,3708,Q24864,Lauredian Union,UL,Unió Laurediana
+AND,3673,Q1257276,Liberal Party of Andorra,Liberals,Liberals d'Andorra
+AND,3676,Q2720389,Greens of Andorra,VA,Els Verds d'Andorra
+AGO,3556,Q1129430,Broad Convergence for the Salvation of Angola,,
+AGO,5131,Q907051,National Liberation Front of Angola,FNLA,Frente Nacional de Libertação de Angola
+AGO,2298,Q28551,People's Movement for the Liberation of Angola,MPLA,
+AGO,2342,Q1674856,Social Renewal Party,,Partido de Renovação Social
+AGO,5136,Q2613567,Liberal Democratic Party,,
+AGO,2343,Q28699,National Union for the Total Independence of Angola,,União Nacional para a Independência Total de Angola
+AIA,3872,Q2838205,Anguilla National Alliance,,
+AIA,6432,Q4763978,Anguilla United Front,,
+AIA,3870,Q4763979,Anguilla United Movement,,
+AIA,6923,Q4763976,Anguilla Progressive Party,,
+ATG,4144,Q1277738,Antigua and Barbuda Labour Party,ABLP,
+ATG,4152,Q4774783,Antigua Caribbean Liberation Movement,,
+ATG,4145,Q4774789,Antigua People's Party,,
+ATG,5552,Q3038017,Barbuda People's Movement,BPM,
+ATG,4151,Q7248757,Progressive Labour Movement,,
+ATG,4149,Q7888291,United National Democratic Party,,
+ATG,4148,Q7889038,United People's Movement,,
+ATG,4150,Q1285399,United Progressive Party,UPP,
+ARG,6112,Q4677212,Action for the Republic,,Acción por la República
+ARG,1215,Q1104292,Civic Coalition ARI,CC/ARI,Coalición Cívica ARI
+ARG,6116,Q4732411,"Alliance for Work, Justice and Education",ALIANZA,"Alianza para el Trabajo, la Justicia y la Educación"
+ARG,7049,Q64590412,Juntos por el Cambio,JxC,Juntos por el Cambio
+ARG,6159,Q1104292,Civic Coalition ARI,CC/ARI,Coalición Cívica ARI
+ARG,2529,Q5152905,Commitment to Change,,Compromiso para el Cambio
+ARG,5088,Q5158911,Concordancia,,Concordancia
+ARG,8672,Q5957490,Kolina,,Corriente de Liberación Nacional
+ARG,5188,Q2723953,Christian Democratic Party,PDC,Partido Demócrata Cristiano
+ARG,7747,Q5668474,Federal Commitment,,Compromiso Federal
+ARG,6161,Q1455518,Broad Progressive Front,FAP,Frente Amplio Progresista
+ARG,7975,Q3088428,Civic Front for Santiago,,Frente Cívico por Santiago
+ARG,6649,Q598744,Workers' Left Front - Unity,FIT/U,Frente de Izquierda y de los Trabajadores – Unidad
+ARG,7743,Q4971885,Broad Front,,Frente Grande
+ARG,8059,Q1053668,Justicialist Party,PJ,Partido Justicialista
+ARG,2530,Q1072438,Front for Victory,FPV,Frente para la Victoria
+ARG,5553,Q359209,Front for a Country in Solidarity,FREPASO,Frente País Solidario
+ARG,6554,Q7248613,"Progressive, Civic and Social Front",FPCyS,"Frente Progresista, Cívico y Social"
+ARG,6160,Q15120034,Renewal Front,FR,Frente Renovador
+ARG,8735,Q5505872,Party of Social Concord,,Frente Renovador de la Concordia Social
+ARG,8128,Q5923742,United Left,,
+ARG,5122,Q6043223,Integration and Development Movement,MID,Movimiento de Integración y Desarrollo
+ARG,868,Q7002024,Neuquén People's Movement,MPN,Movimiento Popular Neuquino
+ARG,4181,Q1951198,Movement for Dignity and Independence,MODIN,Movimiento por la Dignidad y la Independencia
+ARG,1210,Q8034747,Workers' Socialist Movement,MST,Movimiento Socialista de los Trabajadores
+ARG,5192,Q832930,National Autonomist Party,PAN,Partido Autonomista Nacional
+ARG,5121,Q8034724,Workers' Party,PO,Partido Obrero
+ARG,832,Q2358124,Communist Party of Argentina,PC/PCA,Partido Comunista de la Argentina
+ARG,7745,Q2061671,Communist Party of Argentina (Extraordinary Congress),PCCE,Partido Comunista (Congreso Extraordinario)
+ARG,8865,Q6064564,Partido de la Victoria,,Partido de la Victoria
+ARG,5187,Q5255687,Democratic Party,PD,Partido Demócrata de Mendoza
+ARG,5085,Q832976,National Democratic Party,PDN,Partido Demócrata Nacional
+ARG,5112,Q287777,Democratic Progressive Party,PDP,Partido Demócrata Progresista
+ARG,6040,Q5440327,Federal Party (1973),,Partido Federal
+ARG,4180,Q5939363,Humanist Party of Argentina,,Partido Humanista
+ARG,4183,Q2917600,Intransigent Party,PI,Partido Intransigente
+ARG,623,Q1053668,Justicialist Party,PJ,Partido Justicialista
+ARG,5193,Q833103,Labour Party,,Partido Laborista
+ARG,5186,Q6540766,Liberal Party of Corrientes,PL/PLC/PLCo,Partido Liberal de Corrientes
+ARG,8082,Q8034724,Workers' Party,PO,Partido Obrero
+ARG,1365,Q1813766,Socialist Party,PS,Partido Socialista
+ARG,6426,Q833479,Independent Socialist Party,PSI,
+ARG,4204,Q4994345,Federalist Unity Party,,
+ARG,6648,Q5440334,Federal Peronism,,Peronismo Federal
+ARG,1790,Q1507720,Republican Proposal,PRO,Propuesta Republicana
+ARG,8083,Q7252913,Proyecto Sur,,Proyecto Sur
+ARG,1116,Q962693,Recreate for Growth,,Recrear para el Crecimiento
+ARG,5194,Q833458,Democratic Socialist Party,,
+ARG,7664,Q30841057,Citizen's Unity,UC,
+ARG,7188,Q833644,National Civic Union,,Unión Cívica Nacional
+ARG,1724,Q123585,Radical Civic Union,UCR,Unión Cívica Radical
+ARG,5087,Q833748,Intransigent Radical Civic Union,UCRI,Unión Cívica Radical Intransigente
+ARG,4182,Q1795235,Union of the Democratic Centre,UCD/UCeDé,Unión del Centro Democrático
+ARG,5086,Q7896914,Unión Popular,UPF,Unión Popular Federal
+ARG,8736,Q4732336,Union for Córdoba,,Unión por Córdoba
+ARM,2008,Q687937,Justice,,
+ARM,2010,Q868894,Union for National Self-Determination,,
+ARM,2011,Q4314930,National Unity,,Ազգային միաբանություն
+ARM,2009,Q6972251,National Democratic Union,AZhM,Ազգային ժողովրդավարական միություն
+ARM,4205,Q887193,Prosperous Armenia,,Բարգավաճ Հայաստան Կուսակցություն
+ARM,7507,Q27972481,Bright Armenia,,Լուսավոր Հայաստան
+ARM,8012,Q5154330,Communist Party of Armenian Soviet Socialist Republic,,Հայաստանի կոմունիստական կուսակցություն
+ARM,2012,Q4393593,Republic,,Հանրապետություն
+ARM,2013,Q1144610,Republican Party of Armenia,,Հայաստանի Հանրապետական Կուսակցություն
+ARM,2018,Q682280,Armenian Communist Party,,Hayastani Komunistakan Kusaktsutyun
+ARM,4539,Q284853,Armenian National Congress,,Հայ Ազգային Կոնգրես
+ARM,2020,Q318657,Armenian Revolutionary Federation,,Հայ Յեղափոխական Դաշնակցութիւն
+ARM,4365,Q683458,Pan-Armenian National Movement,ՀՀՇ,Հայոց Համազգային Շարժում
+ARM,3783,Q1348278,Heritage,,Ժառանգություն
+ARM,7508,Q58353776,My Step Alliance,,
+ARM,7754,Q17305307,Civil Contract,,Քաղաքացիական Պայմանագիր
+ARM,2016,Q3366799,United Labour Party,,Միավորված աշխատանքային կուսակցություն
+ARM,7800,Q59315322,Mission Party,,Առաքելություն կուսակցություն
+ARM,2007,Q1346313,Rule of Law,,Օրինաց երկիր
+ARM,8804,Q31195347,Tsarukyan Alliance,,
+ARM,8367,Q16888205,People's Party,,
+ABW,5516,Q1288119,Aruban People's Party,,Arubaanse Volkspartij (Dutch)
+ABW,5519,Q7300885,Real Democracy Party,,Democracia Real
+ABW,5518,Q1288512,People's Electoral Movement,,Movimiento Electoral di Pueblo
+ABW,5517,Q12333047,Network of Electoral Democracy,,Democratisch Netwerk (Dutch)
+AUS,1743,Q946040,National Party of Australia,NP/NPA,National Party of Australia
+AUS,777,Q946040,National Party of Australia,NP/NPA,National Party of Australia
+AUS,990,Q781392,Australian Democrats,AD,
+AUS,1209,Q781486,Australian Greens,,
+AUS,424,Q216082,Australian Labor Party,ALP,Australian Labor Party
+AUS,3772,Q2054871,Democratic Labour Party,DLP,Democratic Labor Party
+AUS,6918,Q6508513,Australian Labor Party (New South Wales Branch),,
+AUS,1572,Q781552,Australian Labor Party (Non-Communist),ALP/N/C,
+AUS,6915,Q55604512,Australian Labor Party (Queensland Branch),,
+AUS,6917,Q21003570,Australian Labor Party (South Australian Branch),,
+AUS,1756,Q781308,Australia Party,,
+AUS,323,Q745466,Christian Democratic Party,,
+AUS,451,Q1065320,Coalition,,
+AUS,1999,Q1117010,Liberal Party,,
+AUS,143,Q2496080,Country Liberal Party,CLP,
+AUS,1263,Q1395400,Family First Party,,
+AUS,663,Q1453449,Free Trade Party,,
+AUS,1997,Q6378340,Katter's Australian Party,KAP,
+AUS,248,Q3282553,Lang Labor,,
+AUS,1642,Q23198434,Liberal Party of Australia (South Australian Division),,Liberal Party of Australia (South Australian Division)
+AUS,285,Q1822905,Liberal National Party of Queensland,LNP,
+AUS,1998,Q3366483,Liberal Party,,
+AUS,486,Q241149,Liberal Party of Australia,LP/LPA,Liberal Party of Australia
+AUS,6916,Q24089899,National Defence League,,
+AUS,338,Q1516976,Nationalist Party of Australia,,
+AUS,1736,Q839205,National Labor Party,,
+AUS,5453,Q19876280,Centre Alliance,,
+AUS,1162,Q1585274,One Nation,,
+AUS,1996,Q15130081,United Australia Party,UAP,
+AUS,7012,Q2063859,Pauline's United Australia Party,,
+AUS,454,Q1324190,Protectionist Party,,
+AUS,2104,Q55604512,Queensland Labor Party,,
+AUS,505,Q7455840,Services Party of Australia,,
+AUS,672,Q7603393,State Labor Party,,
+AUS,566,Q1728956,United Australia Party,UAP,
+AUS,1411,Q19876086,National Party of Australia – Victoria,,
+AUS,388,Q17030656,Victorian Farmers' Union,,
+AUS,1058,Q3366259,Western Australian Party,,
+AUT,599,Q653833,Alliance for the Future of Austria,,Bündnis Zukunft Österreich
+AUT,439,Q1828139,Citizens' Forum Austria,,
+AUT,7711,Q341148,Czech Social Democratic Party,ČSSD,Česká strana sociálně demokratická
+AUT,3678,Q692131,Christian Social Party,,Christlichsoziale Partei
+AUT,346,Q1186163,Democratic Progressive Party,,
+AUT,6170,Q277915,Landbund,,
+AUT,6169,Q1204390,German People's Party,,Deutsche Volkspartei
+AUT,1935,Q16943719,Deutsche Nationalpartei (Österreich),,Deutschnationale Partei
+AUT,1659,Q193178,Die Grünen,,Die Grünen – Die Grüne Alternative
+AUT,2991,Q15705373,The Reform Conservatives,,Die Reformkonservativen (REKOS&nbsp;– Liste Ewald Stadler)
+AUT,1500,Q8934466,The Independents (Austria),,
+AUT,8223,Q39073104,Federalist Party,,Föderalistischepartei
+AUT,463,Q131692,Austrian Freedom Party,FPÖ,Freiheitliche Partei Österreichs
+AUT,1917,Q698101,Greater German People's Party,,
+AUT,3304,Q1595552,Heimwehr,,
+AUT,996,Q161118,Communist Party of Austria,,Kommunistische Partei Österreichs
+AUT,1916,Q277915,Landbund,,
+AUT,605,Q699381,Liberal Forum,,Liberales Forum
+AUT,1708,Q688387,Hans-Peter Martin's List,,Liste Hans-Peter Martin
+AUT,6137,Q34198369,NOW – Pilz List,JETZT,JETZT – Liste Pilz
+AUT,6138,Q39049684,My Vote Counts! - G!LT,,Meine Stimme Gilt!
+AUT,7379,Q471367,Old Czech Party,,Národní strana
+AUT,7378,Q1713492,Young Czech Party,,Národní strana svobodomyslná
+AUT,1936,Q7320,National Socialist German Workers' Party (Nazi Party),NSDAP,Nationalsozialistische Deutsche Arbeiterpartei
+AUT,1970,Q13564543,NEOS – The New Austria,,NEOS – Das Neue Österreich und Liberales Forum
+AUT,1329,Q186867,Austrian People's Party,ÖVP,Österreichische Volkspartei
+AUT,7712,Q2568847,Republican Party of Agricultural and Smallholder People,,
+AUT,1384,Q179111,Social Democratic Party of Austria,SPÖ,Sozialdemokratische Partei Österreichs
+AUT,1971,Q103748,Team Stronach,,
+AUT,6044,Q695482,Fatherland Front,,Vaterländische Front
+AUT,1710,Q688585,Federation of Independents,,
+AUT,8222,Q379922,Constitutional Party,,Verfassungspartei
+AZE,1992,Q1751089,Azerbaijani Popular Front Party,,Azərbaycan Xalq Cəbhəsi Partiyası
+AZE,1993,Q724085,Azerbaijan Communist Party (1993),AKP,Azərbaycan Kommunist Partiyası
+AZE,6223,Q2099347,Azerbaijan Communist Party (1920),,Azərbaycan Kommunist Partiyası
+AZE,5877,Q696254,Azerbaijan Hope Party,,Ümid Partiyası
+AZE,3628,Q740271,Musavat Party,,Müsavat Partiyası
+AZE,1995,Q876402,New Azerbaijan Party,YAP,Yeni Azərbaycan Partiyası
+AZE,7050,Q740271,Musavat Party,,Müsavat Partiyası
+BHS,3653,Q5255656,Democratic National Alliance,DNA,
+BHS,3652,Q2566343,Free National Movement,FNM,Free National Movement
+BHS,3284,Q2566823,Progressive Liberal Party,PLP,Progressive Liberal Party
+BHS,7416,Q7887497,United Bahamian Party,,United Bahamian Party
+BHR,5883,Q4115954,Al-Asalah,,جمعية الأصالة الإسلامية
+BHR,5894,Q4702888,Al-Menbar Islamic Society,,جمعية المنبر الوطني الإسلامي
+BHR,5914,Q1131598,Progressive Democratic Tribune,,جمعية المنبر الديمقراطي التقدمي
+BHR,5806,Q1800818,Al Wefaq,,جمعية الوفاق الوطني الإسلامية - الوفاق
+BHR,5916,Q6972195,National Democratic Action Society,,جمعية العمل الوطني الديمقراطي – وعد
+BGD,2299,Q1281480,Bangladesh Awami League,AL,বাংলাদেশ আওয়ামী লীগ
+BGD,2340,Q2475664,Bangladesh Jamaat-e-Islami,,বাংলাদেশ জামায়াতে ইসলামী
+BGD,3782,Q496810,Bangladesh Nationalist Party,BNP,বাংলাদেশ জাতীয়তাবাদী দল
+BGD,5790,Q3346366,BAKSAL,,বাংলাদেশ কৃষক শ্রমিক আওয়ামী লীগ
+BGD,6182,Q48818187,Bangladesh Muslim League,,
+BGD,8680,Q2177973,Communist Party of Bangladesh,CPB,বাংলাদেশের কমিউনিস্ট পার্টি
+BGD,7517,Q5521445,Gano Forum,,গণফোরাম
+BGD,7759,Q5594226,Grand Alliance,,মহাজোট
+BGD,6300,Q3351343,Islami Oikya Jote,,ইসলামী ঐক্য জোট
+BGD,2341,Q1361491,Jatiya Party,JaPa,জাতীয় পার্টি
+BGD,7673,Q6164607,Jatiya Party (Manju),,জাতীয় পার্টি - জেপি
+BGD,3777,Q6164619,Jatiya Samajtantrik Dal,,বাংলাদেশ জাতীয় সমাজতান্ত্রিক দল
+BGD,8568,Q7238121,Praja Party,,
+BGD,8569,Q3322215,Pakistan Muslim League,,پاکستان مسلم لیگ
+BGD,7519,Q4382630,Workers Party of Bangladesh,,বাংলাদেশের ওয়ার্কার্স পার্টি
+BRB,3694,Q740420,Barbados Labour Party,,
+BRB,3686,Q956182,Democratic Labour Party,DLP,
+BLR,2033,Q174439,United Civic Party of Belarus,UCP/English,Аб'яднаная грамадзянская партыя
+BLR,2037,Q396177,Agrarian Party,BAP/English,Белорусская аграрная партия
+BLR,2035,Q815276,Belarusian Social Democratic Party (Assembly),BSDP/Hramada,Беларуская сацыял-дэмакратычная партыя (Грамада)
+BLR,2036,Q1977920,Belarusian Patriotic Party,BPP/English,Белорусская патриотическая партия
+BLR,7406,Q2491997,Belarusian Social Democratic Party (People's Assembly),BSDP/PA/English,Беларуская сацыял-дэмакратычная партыя (Народная Грамада)
+BLR,7418,Q325413,Communist Party of Belarus,CPB/КПБ,Камуністычная партыя Беларусі
+BLR,8376,Q2662463,Communist Party of Byelorussian Soviet Socialist Republic,КПБ,Камуністычная партыя Беларусі
+BLR,3646,Q2994036,Liberal Democratic Party,LDPB/English,Ліберальна-дэмакратычная партыя Беларусі
+BLR,2030,Q772928,"Belarusian Left Party ""A Just World""",,Беларуская партыя левых «Справядлівы свет»
+BLR,3275,Q1729022,BPF Party,PBNF,Партыя БНФ
+BLR,7407,Q2436636,Republican Party of Labour and Justice,RPTS/English,Республиканская партия труда и справедливости
+BEL,528,Q513521,Groen,,Groen
+BEL,480,Q2532509,Belgian Socialist Party,,
+BEL,2289,Q1811565,Belgian Labour Party,,
+BEL,2338,Q113903993,Humanist Democratic Centre,cdH,Centre démocrate humaniste
+BEL,622,Q750673,Christian Democratic and Flemish,CD/V,Christen-Democratisch en Vlaams
+BEL,604,Q750673,Christian Democratic and Flemish,CD/V,Christen-Democratisch en Vlaams
+BEL,1915,Q792290,Christene Volkspartij,,
+BEL,6688,Q1084016,Christlich Soziale Partei,,Christlich Soziale Partei
+BEL,1563,Q655611,Ecolo,,
+BEL,698,Q1470087,DéFI,,
+BEL,191,Q907516,Agir,,Démocratie Nationale
+BEL,3689,Q682708,Frontpartij,,
+BEL,1333,Q17093543,Walloon Front,,
+BEL,1892,Q792293,Catholic Party,,
+BEL,4542,Q3388044,Catholic Flemish People's Party,,
+BEL,302,Q537850,Communist Party of Belgium,KPB/PCB,Kommunistische Partij van België
+BEL,275,Q2636334,Liberal Party,,
+BEL,43,Q130671,"Libertarian, Direct, Democratic",,
+BEL,791,Q2133093,Mouvement des Citoyens pour le Changement,,Mouvement des Citoyens pour le Changement
+BEL,789,Q533384,Reform Movement,MR,Mouvement Réformateur
+BEL,36,Q28982,New Flemish Alliance,N/VA,Nieuw-Vlaamse Alliantie
+BEL,1753,Q925616,Workers' Party of Belgium,,Partij van de Arbeid van België
+BEL,49,Q1160192,Open Flemish Liberals and Democrats,Open/Vld,Open Vlaamse Liberalen en Democraten
+BEL,639,Q929882,People's Party,,
+BEL,554,Q2711996,Liberal Reformist Party,,Parti Réformateur Libéral
+BEL,1829,Q314493,Rexism,,Parti Rexiste
+BEL,633,Q113903993,Humanist Democratic Centre,cdH,Centre démocrate humaniste
+BEL,405,Q3366715,Christian Social Party,PSC,Christelijke Volkspartij
+BEL,500,Q645787,Socialist Party,PS,
+BEL,281,Q2612679,Walloon Rally,,Rassemblement wallon
+BEL,7008,Q762051,Rassemblement Wallonie France,,Rassemblement Wallonie France
+BEL,7015,Q1510441,Sociaal-Liberale Partij,,
+BEL,1680,Q939354,Forward,,Vooruit
+BEL,780,Q2086872,Belgian Democratic Union,,
+BEL,76,Q932768,Vivant,,
+BEL,1968,Q682990,Flemish Interest,,Vlaams Belang
+BEL,553,Q597900,Vlaams Blok,,
+BEL,3879,Q2337095,Flemish National Union,,Vlaamsch Nationaal Verbond
+BEL,1424,Q1725837,People's Union,,Volksunie
+BLZ,4088,Q5255865,Democratic and Agricultural Labour Party,,
+BLZ,4087,Q5892936,Honduran Independence Party,,
+BLZ,5839,Q6970292,National Alliance for Belizean Rights,,
+BLZ,4085,Q17139489,National Independence Party,,
+BLZ,4086,Q6974787,National Party,,
+BLZ,3739,Q1759613,People's United Party,,
+BLZ,3738,Q1809323,United Democratic Party,,
+BEN,8871,Q4732473,Alliance of the Forces of Progress,,alliance des forces du progrès
+BEN,7051,Q18161936,Alliance for Democracy and Progress,,alliance pour la démocratie et le progrès
+BEN,7071,Q4732413,Alliance for a Democratic Dynamic,,alliance pour une dynamique démocratique
+BEN,8857,Q20982217,Sun Alliance,,alliance soleil
+BEN,7194,Q18161664,African People's Bloc,,bloc populaire africain
+BEN,5903,Q18161658,African Congress for Renewal,,congrès africain pour le renouveau
+BEN,5920,Q18351111,Democratic Party of Benin,,parti démocratique du Bénin
+BEN,6190,Q3076831,Key Force,,Force Clé
+BEN,7061,Q16909755,Hope Force,,Force Espoir
+BEN,2300,Q5179821,Cowry Forces for an Emerging Benin,,Forces Cauris pour un Bénin émergent
+BEN,4089,Q3088445,Action Front for Renewal and Development,,Front d'action pour le renouveau et le développement
+BEN,2366,Q18356732,G13 Baobab Alliance,,alliance G13 baobab
+BEN,4720,Q18349960,Dahomeyan Democratic Movement,,groupement ethnique du Nord
+BEN,8870,Q6007999,Impulse to Progress and Democracy,,impulsion au progrès et la démocratie
+BEN,5900,Q4689865,African Movement for Development and Progress,,mouvement africain pour la développement et le progrès
+BEN,7053,Q18391604,National Movement for Democracy and Development,,mouvement nationale pour la démocratie et le développement
+BEN,7054,Q18391359,"Movement for Solidarity, Union and Progress",,"mouvement pour la solidarité, l'union et le progrès"
+BEN,5902,Q6926624,Movement for Citizens' Commitment and Awakening,,mouvement pour l'engagement et le réveil des citoyens
+BEN,3836,Q18358728,Our Common Cause,,notre cause commune
+BEN,3828,Q4896906,Communist Party of Benin,,Parti Communiste du Bénin
+BEN,5448,Q18349973,Dahomeyan Unity Party,,Parti Dahoméen de l'Unité
+BEN,3831,Q4888024,Benin Rebirth Party,,Parti de la renaissance du Bénin
+BEN,5413,Q478120,People's Revolutionary Party of Benin,,Parti de la révolution populaire du Bénin
+BEN,5776,Q18349964,Dahomeyan Democratic Party,,Parti Démocratique Dahoméen
+BEN,2365,Q5255784,Democratic Renewal Party,,Parti du renouveau démocratique
+BEN,5882,Q6974784,"National Party ""Together""",,parti national ensemble
+BEN,6450,Q18379571,National Party for Democracy and Development,,parti national pour la démocratie et le développement
+BEN,4718,Q18394066,Republican Party of Dahomey,,parti républicain dahoméen
+BEN,7059,Q20982206,Patriotic Revival Party,,parti réveil patriotique
+BEN,2368,Q3088954,Social Democratic Party,,Parti Social-Démocrate
+BEN,5921,Q7406327,Party of Salvation,,parti du salut
+BEN,3841,Q18350381,African Rally for Progress and National Solidarity,,rassemblement africain pour le progrès et la solidarité nationale
+BEN,5775,Q1162619,Rassemblement Démocratique du Dahomé,,rassemblement démocratique dahoméen
+BEN,3839,Q6540656,Liberal Democrats' Rally for National Reconstruction – Vivoten,,Rassemblement des Démocrates Libéraux pour la Reconstruction nationale
+BEN,3834,Q6975195,National Rally for Democracy,RND,Rassemblement national pour la démocratie
+BEN,7096,Q18393332,Rally for Progress and Renewal,,Rassemblement pour le Progrès et le Renouveau
+BEN,4719,Q18205675,Dahomeyan Democratic Union,,union democratique dahoméenne
+BEN,6569,Q7885823,Union Makes the Nation,,L'Union fait la Nation
+BEN,4091,Q6979093,National Union for Democracy and Progress,,union nationale pour la démocratie et le progrès
+BEN,7052,Q18379630,National Union for Solidarity and Progress,,union nationale pour la solidarité et le progrès
+BEN,7055,Q18356540,Union for Democracy and National Reconstruction,,union pour la démocratie et la reconstruction nationale
+BEN,4090,Q7886425,Union for Democracy and National Solidarity,,union pour la démocratie et la solidarité nationale
+BEN,7060,Q7886463,Union for Relief,,union pour la relève
+BEN,8753,Q18356539,Union for Benin,,union pour le Bénin
+BEN,7072,Q18356556,Union for the Triumph of Democratic Renewal,,union pour le triomphe du renouveau démocratique
+BEN,7193,Q18205681,Dahomeyan Progressive Union,,union progressiste dahoméenne
+BMU,3722,Q6974096,National Liberal Party,,
+BMU,3790,Q7092478,One Bermuda Alliance,,
+BMU,3721,Q1565799,Progressive Labour Party,,
+BMU,3723,Q1565805,United Bermuda Party,,
+BTN,3820,Q15980884,Druk Chirwang Tshogpa,,འབྲུག་སྤྱིར་དབང་ཚོགས་པ་
+BTN,3303,Q15980883,Druk Nyamrup Tshogpa,DNT,
+BTN,3822,Q2035999,Bhutan Peace and Prosperity Party,DPT,
+BTN,3823,Q2578342,People's Democratic Party,PDP,
+BOL,4393,Q2823680,Nationalist Democratic Action,,Acción Democrática Nacionalista
+BOL,6059,Q56276342,Patriotic Accord,AP,Acuerdo Patriótico
+BOL,7069,Q5153015,Committee of National Unity,,
+BOL,8126,Q71529396,Civic Community,,
+BOL,4396,Q5162725,Conscience of Fatherland,CONDEPA,
+BOL,8314,Q5158904,Concordance,,Concordancia
+BOL,4051,Q1450907,Bolivian Socialist Falange,,Falange Socialista Boliviana
+BOL,170,Q202609,National Unity Front,,Frente de Unidad Nacional
+BOL,6028,Q7318805,Revolutionary Left Front,,Frente Revolucionario de Izquierda
+BOL,5143,Q1296335,Movement without Fear,,Movimiento Sin Miedo
+BOL,442,Q1142239,Movement for Socialism,MAS/IPSP,
+BOL,4398,Q642234,Free Bolivia Movement,,Movimiento Bolivia Libre
+BOL,4387,Q1951202,Revolutionary Left Movement,,Movimiento de la Izquierda Revolucionaria – Nueva Mayoría
+BOL,8312,Q3021809,Democrat Social Movement,,Movimiento Demócrata Social
+BOL,4392,Q4120518,Pachakuti Indigenous Movement,,Movimiento Indígena Pachakuti
+BOL,4399,Q17073687,Indian Movement Túpac Katari,,
+BOL,568,Q1536051,Revolutionary Nationalist Movement,,Movimiento Nacionalista Revolucionario
+BOL,4389,Q17075676,Leftwing Revolutionary Nationalist Movement,,
+BOL,7417,Q6979798,Nationalist Revolutionary Movement of the People,,
+BOL,8695,Q7229670,Popular Christian Movement,,Movimiento Popular Cristiano
+BOL,8694,Q7318813,Revolutionary Liberation Movement Tupaq Katari,,
+BOL,4388,Q7853483,Tupaj Katari Revolutionary Movement,,
+BOL,4386,Q7011171,New Republican Force,,Nueva Fuerza Republicana
+BOL,8693,Q1670332,Communist Party of Bolivia,P/C/B,Partido Comunista de Bolivia
+BOL,5107,Q7318808,Revolutionary Left Party,,Partido de la Izquierda Revolucionaria
+BOL,5106,Q7314703,Republican Socialist Unity Party,,Partido de la Unión Republicana Socialista
+BOL,5139,Q2605787,Christian Democratic Party,,Partido Demócrata Cristiano
+BOL,5108,Q3366486,Liberal Party,,Partido Liberal
+BOL,5110,Q12132985,Nationalist Party,,Partido Nacionalista
+BOL,7068,Q4391779,Revolutionary Workers' Party,,
+BOL,5381,Q7314618,Republican Party,,Partido Republicano
+BOL,5111,Q5533819,Genuine Republican Party,,Partido Republicano Genuino
+BOL,5109,Q7551742,Socialist Republican Party,,Partido Republicano Socialista
+BOL,4394,Q4825871,Authentic Revolutionary Party,,Partido Revolucionario Auténtico
+BOL,7070,Q4863578,Barrientista Revolutionary Party,,
+BOL,8315,Q4888105,Revolutionary Party of the Nationalist Left,,
+BOL,6047,Q7550546,Social Democratic Party,,
+BOL,4401,Q7551628,Socialist Party,,
+BOL,7195,Q6017222,Independent Socialist Party,,
+BOL,6230,Q17041921,Independent Socialist Party,,
+BOL,6246,Q7889157,United Socialist Party,,Partido Socialista Unificado
+BOL,4384,Q7551626,Socialist Party-1,,Partido Socialista-1
+BOL,5138,Q18346105,Green Party of Bolivia,,Partido Verde de Bolivia
+BOL,1238,Q488787,Social and Democratic Power,,Poder Democrático Social
+BOL,4395,Q5124336,Solidarity Civic Unity,,Unidad Cívica Solidaridad
+BOL,4400,Q5255868,Democratic and Popular Union,,
+BOL,7715,Q4863577,Barrientista National Union,,
+BIH,3683,Q594292,Bosnian-Herzegovinian Patriotic Party-Sefer Halilović,,Bosanskohercegovačka patriotska stranka
+BIH,7801,Q18415962,Croatian Peasant Party of Bosnia and Herzegovina,,Hrvatska seljačka stranka Bosne i Hercegovine
+BIH,4717,Q13231807,Democratic Front (Bosnia and Herzegovina),,Demokratska fronta
+BIH,1159,Q1275468,Democratic People's Union,,Demokratska narodna zajednica BiH
+BIH,3170,Q2632431,Democratic People's Alliance,,Демократски народни савез
+BIH,5464,Q2912096,Citizens' Democratic Party,,Građanska demokratska stranka
+BIH,3168,Q1289053,Croatian Democratic Union 1990,,Hrvatska demokratska zajednica 1990
+BIH,1760,Q16792,Croatian Democratic Union of Bosnia and Herzegovina,HDZBiH,Hrvatska demokratska zajednica Bosne i Hercegovine
+BIH,7196,Q1250158,Croat People's Union,,Hrvatska narodna zajednica
+BIH,1128,Q1789636,Croatian Party of Rights of Bosnia and Herzegovina,,Hrvatska stranka prava Bosne i Hercegovine
+BIH,6618,Q921704,Liberal Democratic Party,,Liberalno demokratska stranka
+BIH,3240,Q1288920,People's Party For Work And Betterment,,Narodna stranka Radom za Boljitak
+BIH,4716,Q18420177,National Democratic Movement,,Народни демократски покрет
+BIH,8624,Q946306,Our Party,,Naša stranka
+BIH,8806,Q59748543,Independent Bloc,,
+BIH,1673,Q1648272,Party of Democratic Progress,PDP,
+BIH,1,Q533141,League of Communists of Bosnia and Herzegovina,,
+BIH,292,Q1258283,Alliance of Independent Social Democrats,SNSD/СНСД,
+BIH,3171,Q3612403,Union for a Better Future of BiH,,Savez za bolju budućnost BiH
+BIH,537,Q1143161,Social Democratic Party of Bosnia and Herzegovina,,Socijaldemokratska partija
+BIH,998,Q1276922,Socialist Party,,Социјалистичка Партија
+BIH,1166,Q1164533,Serbian Democratic Party,,Српска демократска странка
+BIH,1222,Q2631757,Serbian Radical Party of the Republika Srpska,,Српска радикална странка Републике Српске
+BIH,6619,Q7452875,Serbian People's Alliance of the Republika Srpska,,
+BIH,1454,Q1132677,Party of Democratic Action,,Stranka demokratske akcije
+BIH,357,Q290118,Party for Bosnia and Herzegovina,,Stranka za
+BWA,3633,Q4893655,Botswana Alliance Movement,,
+BWA,2337,Q4894021,Botswana Congress Party,,
+BWA,2301,Q859825,Botswana Democratic Party,BDP,
+BWA,2336,Q2310801,Botswana National Front,,
+BWA,3632,Q4893988,Botswana People's Party,,
+BWA,4832,Q18347306,Umbrella for Democratic Change,UDC,
+BRA,4614,Q2745857,National Renewal Alliance Party,ARENA,Aliança Renovadora Nacional
+BRA,8291,Q7335317,Rio Republican Party,,Partido Republicano Fluminense
+BRA,4615,Q1322751,Democratic Movement Party,MDB,Movimento Democrático Brasileiro
+BRA,2489,Q2597196,Brazilian Communist Party,PCB,Partido Comunista Brasileiro
+BRA,565,Q504000,Communist Party of Brazil,PCdoB,Partido Comunista do Brasil
+BRA,8386,Q2016956,Conservative Party,,Partido Conservador
+BRA,1536,Q1185830,Democrats,DEM,Democratas
+BRA,4410,Q2534868,Christian Labour Party,PTC,Partido Trabalhista Cristão
+BRA,4405,Q2731720,Liberal Party,PR,Partido Liberal
+BRA,225,Q1322897,Brazilian Social Democracy Party,PSDB,Partido da Social Democracia Brasileira
+BRA,4403,Q3366416,Christian Democratic Party,,Partido Democrata Cristão
+BRA,1163,Q1713552,Democratic Social Party,,Partido Democrático Social
+BRA,1009,Q1414708,Democratic Labour Party,PDT,Partido Democrático Trabalhista
+BRA,4404,Q1636064,Party of the Reconstruction of the National Order,,Partido da Reedificação da Ordem Nacional
+BRA,4859,Q7141106,Party of Popular Representation,,Partido de Representação Popular
+BRA,654,Q1322751,Democratic Movement Party,MDB,Movimento Democrático Brasileiro
+BRA,356,Q657089,Workers' Party,PT,Partido dos Trabalhadores
+BRA,7078,Q2453205,Humanist Party of Solidarity,PHS,Partido Humanista da Solidariedade
+BRA,1823,Q111525667,Partido Liberal,,Partido Liberal
+BRA,267,Q2598527,Cidadania,PPS,Partido Popular Socialista
+BRA,781,Q732852,Progressive Party,PP,Progressistas
+BRA,4402,Q3366642,Reform Progressive Party,,Partido Progressista Reformador
+BRA,8290,Q2453861,Brazilian Labour Renewal Party,PRTB,Partido Renovador Trabalhista Brasileiro
+BRA,4408,Q10345672,Republican Party,,Partido Republicano
+BRA,7079,Q926973,Republicanos,PRB,Republicanos
+BRA,6335,Q5163092,Conservative Republican Party,,Partido Republicano Conservador
+BRA,6958,Q15564211,Republican Party of the Social Order,PROS,Partido Republicano da Ordem Social
+BRA,6048,Q834073,Mineiro Republican Party,PRM,Partido Republicano Mineiro
+BRA,6318,Q7314669,Republican Party of São Paulo,,Partido Republicano Paulista
+BRA,861,Q2626213,Social Christian Party,PSC,Partido Social Cristão
+BRA,4613,Q2054750,Social Democratic Party,PSD,Partido Social Democrático
+BRA,3816,Q2626216,Social Democratic Party,,Partido Social Democrático
+BRA,501,Q1754827,Socialism and Freedom Party,PSOL,Partido Socialismo e Liberdade
+BRA,723,Q2054789,Brazilian Socialist Party,PSB,Partido Socialista Brasileiro
+BRA,6920,Q2366265,Social Liberal Party,PSL,Partido Social Liberal
+BRA,4409,Q7550752,Social Progressive Party,,
+BRA,4406,Q2601478,Social Labour Party,PST,
+BRA,458,Q1576143,Brazilian Labour Party,PTB,Partido Trabalhista Brasileiro
+BRA,4616,Q15980784,Brazilian Labour Party,,Partido Trabalhista Brasileiro
+BRA,4650,Q3181274,Podemos,PODE,
+BRA,547,Q1234489,Green Party,PV,Partido Verde
+BRA,6959,Q20061311,Solidarity,SD,Solidariedade
+BRA,4407,Q2777993,National Democratic Union,,União Democrática Nacional
+VGB,3760,Q6972226,National Democratic Party,NDP,
+VGB,6989,Q17112851,VI Democratic Party,VIDP,Virgin Island Democratic Party
+VGB,3752,Q7933937,Virgin Islands Party,,
+BRN,8678,Q6581402,National Development Party (Brunei),,
+BRN,8679,Q4978924,Brunei National Solidarity Party,,
+BGR,7809,Q764717,"Agrarian Union ""Aleksandar Stamboliyski""",ZS/AS,Земеделски съюз
+BGR,3187,Q17173534,Alternative for Bulgarian Revival,ABV,Алтернатива за българско възраждане
+BGR,3188,Q16943183,Bulgaria Without Censorship,,Презареди България
+BGR,5105,Q4090673,Bulgarian Social Democratic Workers Party (Broad Socialists),,
+BGR,6751,Q4090669,Bulgarian Social Democratic Workers' Party (Narrow Socialists),,
+BGR,757,Q752259,Bulgarian Socialist Party,BSP,Българска социалистическа партия
+BGR,1027,Q15637437,Bulgarian Business Bloc,,Български бизнес блок
+BGR,263,Q834030,Bulgarian People's Union,,Български народен съюз
+BGR,8260,Q21409398,Bulgarian National Union – New Democracy,,Български национален съюз - Нова демокрация
+BGR,2060,Q834016,Bulgarian Agrarian National Union,,Български земеделски народен съюз
+BGR,6754,Q155000,Bulgarian Communist Party,БКП,Българска Комунистическа Партия
+BGR,8355,Q1003898,Bulgarian New Democracy,,
+BGR,6750,Q2022865,Bulgarian Workers' Social Democratic Party,,Българска работническа социалдемократическа партия
+BGR,149,Q3060519,Bulgarian Euro-Left,,Българска Евролевица
+BGR,5861,Q29046899,"Yes, Bulgaria!",,"Да, България!"
+BGR,6749,Q903793,Democratic Party,,Демократическа партия
+BGR,5133,Q2129973,Democratic Alliance,,Демократически сговор
+BGR,5860,Q26206042,"Democrats for Responsibility, Solidarity and Tolerance",DOST,
+BGR,1195,Q127205,Democrats for a Strong Bulgaria,DSB,Демократи за силна България
+BGR,2058,Q10785508,Bulgaria for Citizens Movement,,Движение „България на гражданите“
+BGR,1820,Q3657993,George's Day Movement,,Движение Гергьовден
+BGR,982,Q164242,Movement for Rights and Freedoms,DPS/Bulgarian,
+BGR,2024,Q20497195,People's Voice,,Глас народен
+BGR,760,Q133968,Citizens for European Development of Bulgaria,ГЕРБ,ГЕРБ
+BGR,1665,Q971439,Coalition for Bulgaria,BSPzB,БСП за България
+BGR,603,Q2351908,Communist Party of Bulgaria,,Комунистическа Партия на България
+BGR,6744,Q3623127,Conservative Party,,Консервативна партия
+BGR,6743,Q1822925,Liberal Party (Bulgaria),,Либерална партия
+BGR,6747,Q2976213,Liberal Party (Radoslavists),,Либерална партия (радослависти)
+BGR,265,Q951851,Lider,,Български Демократичен Център
+BGR,6752,Q11813063,Young Liberals Party,,Младолиберална партия
+BGR,374,Q928435,National Movement for Stability and Progress,NDSV/Bulgarian,Национално движение за стабилност и възход
+BGR,6746,Q2918912,People's Party (Bulgaria),,Народна партия
+BGR,6745,Q1134127,People's Liberal Party,,Народнолиберална партия
+BGR,8391,Q3866613,National Social Movement,,Народно социално движение
+BGR,1793,Q178049,National Union Attack,,Атака
+BGR,5132,Q12287901,National Liberal Party (Bulgaria),,Националлиберална партия
+BGR,2057,Q1968054,National Front for the Salvation of Bulgaria,NFSB/Bulgarian,Национален фронт за спасение на България
+BGR,1183,Q265322,United Democratic Forces,,
+BGR,6115,Q27499882,United Patriots,OP,Обединени Патриоти
+BGR,6189,Q2453048,Fatherland Front,,Отечествен фронт
+BGR,661,Q127790,Party of Bulgarian Social Democrats,,партия Български социалдемократи
+BGR,5649,Q17514144,Patriotic Front,,Патриотичен фронт
+BGR,8187,Q16943183,Bulgaria Without Censorship,,Презареди България
+BGR,6748,Q8014913,Progressive Liberal Party,,Прогресивнолиберална партия
+BGR,5593,Q1133279,Radical Democratic Party,,
+BGR,272,Q1048010,"Order, Law and Justice",,"Ред, законност и справедливост"
+BGR,3189,Q15991304,Reformist Bloc,RB,Реформаторски блок
+BGR,8033,Q897740,Union of Free Democrats,,Съюз на свободните демократи
+BGR,482,Q841253,Union of Democratic Forces,СДС,Съюз на демократичните сили
+BGR,58,Q677080,Blue Coalition,,Синя коалиция
+BGR,5862,Q28943121,Revival,,Възраждане
+BGR,2056,Q792527,VMRO – Bulgarian National Movement,VMRO,ВМРО – Българско Национално Движение
+BGR,5863,Q25485773,Volya,,Движение Воля
+BGR,659,Q851822,Green Party of Bulgaria,,Зелена партия
+BGR,747,Q804936,Agrarian People's Union,ZNS,Земеделски народен съюз
+BGR,5104,Q1507295,Zveno,,Звено
+BFA,5774,Q16147080,African Democratic Rally,,Rassemblement Démocratique Africain
+BFA,4314,Q2646749,Alliance for Democracy and Federation – African Democratic Rally,,Alliance pour la Démocratie et la Fédération–Rassemblement Démocratique Africain
+BFA,4313,Q592045,Congress for Democracy and Progress,CDP,Congrès pour la Démocratie et le Progrès
+BFA,8740,Q5166263,Convention of Democratic Forces,,
+BFA,7331,Q2132031,Rally of the French People,,Rassemblement du peuple français
+BFA,8739,Q18618872,Alternative Faso,,
+BFA,5769,Q21604403,People's Movement for Progress,MPP,
+BFA,7207,Q4689885,African Popular Movement,,
+BFA,5925,Q22079709,New Era for Democracy,,Nouveau Temps pour la Démocratie
+BFA,5904,Q22079707,New Alliance of Faso,,
+BFA,5923,Q18618899,Organisation for Democracy and Labour,ODT,Organisation pour la démocratie et le travail
+BFA,4320,Q4689797,African Independence Party,,Parti Africain de l'Indépendance
+BFA,7369,Q1455532,Democratic Party of Côte d'Ivoire – African Democratic Rally,PDCI/RDA,Parti Démocratique de la Côte d'Ivoire — Rassemblement Démocratique Africain
+BFA,7205,Q7884919,Unified Democratic Party,,
+BFA,7330,Q18395733,Voltaic Democratic Party,,
+BFA,5901,Q3366613,Party for Democracy and Progress,,
+BFA,4317,Q7140994,Party for Democracy and Socialism/Metba,,Parti pour la démocratie et le socialisme/Metba
+BFA,6415,Q4847084,Popular Front,,
+BFA,4316,Q2494809,Union for Rebirth / Sankarist Movement,,
+BFA,5768,Q2494809,Union for Rebirth / Sankarist Movement,,
+BFA,4318,Q2494813,Union for the Republic,,
+BFA,4315,Q1431782,Union for Progress and Reform,UPC,Union pour le Progrès et le Changement
+BFA,5899,Q18618918,Voltaic Progressive Front,,
+BDI,5266,Q2271402,National Council for the Defense of Democracy–Forces for the Defense of Democracy,,Conseil National Pour la Défense de la Démocratie–Forces pour la Défense de la Démocratie
+BDI,5265,Q647532,Front for Democracy in Burundi,,Front pour la Démocratie au Burundi
+BDI,7095,Q22079894,Independents of Hope,,
+BDI,8916,Q7287091,Rally for the People of Burundi,,
+BDI,5263,Q633163,Union for National Progress,,Union pour le Progrès national
+KHM,8918,Q4984256,Buddhist Liberal Democratic Party,,
+KHM,5521,Q5025162,Cambodian National Rescue Party,CNRP,
+KHM,4722,Q3073267,Democratic Party,,
+KHM,5830,Q2598946,National United Front of Kampuchea,,រណសិរ្សរួបរួមជាតិកម្ពុជា
+KHM,8505,Q3278067,Kampuchean United Front for National Salvation,,Front Uni National pour le Salut du Kampuchéa
+KHM,3764,Q117815,Funcinpec Party,,ហ្វ៊ុនស៊ិនប៉ិច
+KHM,3765,Q769308,Cambodian People's Party,CPP/since/1991,
+KHM,3762,Q1640181,Sam Rainsy Party,,
+KHM,3763,Q1857742,Human Rights Party,,
+KHM,6888,Q25351591,Liberal Party,,
+KHM,8917,Q3051895,Khmer People's National Liberation Front,,រណសិរ្សរំដោះជាតិប្រជាជនខ្មែរ
+KHM,8737,Q6508956,League for Democracy Party,LDP,
+KHM,3761,Q120538,Norodom Ranariddh Party,NRP,គណបក្ស នរោត្ដម រណឫទ្ធិ
+KHM,8506,Q8711543,Communist Party of Kampuchea,,បក្សកុម្មុយនីស្តកម្ពុជា
+KHM,6887,Q4921442,Social Republican Party,,
+KHM,8919,Q3366376,Party of Democratic Kampuchea,,គណបក្សកម្ពុជាប្រជាធិបតេយ្យ
+KHM,4721,Q2401103,Sangkum,,សង្គមរាស្ត្រនិយម
+CMR,5409,Q18737112,Cameroon People's National Convention,,
+CMR,6572,Q18737142,Kamerun National Congress,,
+CMR,6338,Q12350429,Kamerun National Democratic Party,,
+CMR,6575,Q20982151,Cameroonian National Action Movement,,
+CMR,8612,Q20982150,Cameroon Renaissance Movement,,
+CMR,6573,Q18737180,One Kamerun,,
+CMR,5412,Q3366357,Cameroonian Party of Democrats,,
+CMR,3774,Q953447,Cameroon People's Democratic Movement,,Rassemblement démocratique du Peuple Camerounais
+CMR,3682,Q1470113,Social Democratic Front,,Front Social Démocrate
+CMR,5410,Q5026464,Cameroonian Union,,Union camérounaise
+CMR,3773,Q3550257,Cameroon Democratic Union,,
+CMR,5411,Q1860584,Union of the Peoples of Cameroon,UPC,Union des Populations du Cameroun
+CMR,5791,Q953447,Cameroon People's Democratic Movement,,Rassemblement démocratique du Peuple Camerounais
+CMR,3775,Q6979097,National Union for Democracy and Progress,,
+CAN,3640,Q574591,Anti-Confederation Party,,
+CAN,407,Q2906769,Bloc populaire,,
+CAN,1428,Q735105,Bloc Québécois,,Bloc québécois
+CAN,1332,Q546881,Canadian Alliance,,Alliance réformiste-conservatrice canadienne
+CAN,875,Q2160378,Communist Party of Canada,CPC/English,Parti communiste du Canada
+CAN,3642,Q909827,Conservative Party of Canada,,Conservative Party of Canada
+CAN,1004,Q488523,Conservative Party of Canada,,Parti conservateur du Canada
+CAN,3629,Q1104026,Co-operative Commonwealth Federation,,
+CAN,931,Q691730,Green Party of Canada,,Parti vert du Canada
+CAN,1739,Q138345,Liberal Party of Canada,LPC/English,Parti libéral du Canada
+CAN,2000,Q6974810,National Party of Canada,,Parti national du Canada
+CAN,152,Q130765,New Democratic Party,NDP/English,Nouveau Parti démocratique
+CAN,3641,Q3370099,Patrons of Industry,,
+CAN,8636,Q56612740,People's Party of Canada,PPC,Parti populaire du Canada
+CAN,232,Q1292617,Progressive Conservative Party of Canada,,Parti progressiste-conservateur du Canada
+CAN,1930,Q2112263,Progressive Party of Canada,,Progressive Party of Canada
+CAN,973,Q3418128,Ralliement créditiste,,
+CAN,1932,Q7302781,Reconstruction Party of Canada,,
+CAN,1757,Q1680589,Reform Party of Canada,,Parti réformiste du Canada
+CAN,1940,Q3024104,Rhinoceros Party,,Parti Rhinocéros
+CAN,1156,Q951941,Social Credit Party of Canada,,Parti Crédit social du Canada
+CAN,1972,Q3418128,Ralliement créditiste,,
+CAN,4830,Q1809831,United Farmers of Alberta,,
+CPV,3793,Q1951190,Movement for Democracy,,Movimento para a Democracia
+CPV,5792,Q776352,African Party for the Independence of Guinea and Cape Verde,PAIGC,Partido Africano para a Independência da Guiné e Cabo Verde
+CPV,3796,Q497464,African Party for the Independence of Cape Verde,PAICV,Partido Africano da Independência de Cabo Verde
+CPV,3770,Q5255592,Democratic Convergence Party,,
+CPV,3794,Q5255783,Democratic Renewal Party,,
+CPV,3792,Q3550046,Democratic and Independent Cape Verdean Union,,União Caboverdiana Independente e Democrática
+CYM,3787,Q7165720,People's Progressive Movement,,People's Progressive Movement
+CYM,3788,Q7887698,Cayman Democratic Party,,
+CAF,5606,Q4732361,Alliance for Democracy and Progress,,
+CAF,8873,Q20982137,National Convention,,
+CAF,8411,Q20982125,Civic Forum,,
+CAF,6501,Q3078639,Democratic Forum for Modernity,,
+CAF,5607,Q2274551,Patriotic Front for Progress,,
+CAF,6193,Q15984948,Movement for Democracy and Development,,Mouvement pour la Démocratie et le Développement
+CAF,4897,Q3326601,Movement for the Liberation of the Central African People,,Mouvement pour la Libération du Peuple Centrafricain
+CAF,4710,Q1951132,Movement for the Social Evolution of Black Africa,MESAN,Mouvement pour l'évolution sociale de l'Afrique noire
+CAF,4896,Q1968085,"National Convergence ""Kwa Na Kwa""",,"Convergence Nationale ""Kwa Na Kwa"""
+CAF,7494,Q20312140,Action Party for Development,,
+CAF,6504,Q6979204,National Unity Party,,
+CAF,5609,Q20982130,Liberal Democratic Party,,
+CAF,5608,Q7550550,Social Democratic Party,,
+CAF,5808,Q1582199,Central African Democratic Rally,,Rassemblement Démocratique Centrafricain
+CAF,6365,Q2494581,Central African Democratic Union,,Union Démocratique Centrafricaine
+CAF,7535,Q20982140,National Union for Democracy and Rally,,
+CAF,7537,Q23900268,Union for Central African Renewal,,Union pour le renouveau centrafricain
+TCD,4708,Q5066454,Chadian Social Action,,
+TCD,4709,Q1970314,Chadian Progressive Party,,Parti Progressiste Tchadien
+TCD,6577,Q5611313,Grouping of Rural and Independent Chadians,,
+TCD,5503,Q1576278,Patriotic Salvation Movement,MPS,Mouvement Patriotique du Salut
+TCD,6742,Q3326838,African Socialist Movement,,
+TCD,7048,Q6017245,Independent Socialist Party of Chad,,
+TCD,5595,Q3623619,Rally for Democracy and Progress,RDP,
+TCD,7047,Q2164587,Democratic and Socialist Union of the Resistance,,Union démocratique et socialiste de la Résistance
+TCD,7219,Q3550258,Chadian Democratic Union,,
+TCD,5821,Q1168907,National Union for Democracy and Renewal,UNDR,Union nationale pour la démocratie et le renouveau
+TCD,5820,Q6979102,National Union for Independence and Revolution,,Union Nationale pour l'indépendance et la révolution
+TCD,5502,Q669116,Union for Renewal and Democracy,URD,
+CHL,8707,Q5656224,Independent Popular Action,,Acción Popular Independiente
+CHL,6061,Q1140651,Alianza,,Alianza
+CHL,4822,Q7229694,Popular Freedom Alliance,,Alianza Popular Libertadora
+CHL,8296,Q5494986,Liberal Alliance,,
+CHL,7020,Q16488420,Amplitude,,Amplitud
+CHL,7022,Q15984941,Citizens,,Ciudadanos
+CHL,4550,Q943126,Concertación,,Concertación de Partidos por la Democracia
+CHL,4640,Q7280424,Radical Democracy Party,,Democracia Radical
+CHL,7021,Q16565533,Political Evolution,,Evolución Política
+CHL,7023,Q28868044,Social Green Regionalist Federation,FREVS,Federación Regionalista Verde Social
+CHL,4549,Q2719886,Juntos Podemos Más,,
+CHL,812,Q6025076,MAS Region,,MAS Región
+CHL,4829,Q1138554,Popular Unitary Action Movement,,Movimiento de Acción Popular Unitaria
+CHL,6060,Q14539865,New Majority,,Nueva Mayoría
+CHL,4636,Q4693749,Agrarian Labor Party,,Partido Agrario Laborista
+CHL,162,Q317952,Communist Party of Chile,,Partido Comunista de Chile
+CHL,4643,Q639673,Conservative Party,,Partido Conservador
+CHL,4641,Q7550472,Social Christian Conservative Party,,Partido Conservador Social Cristiano
+CHL,4639,Q6063982,Traditionalist Conservative Party,,Partido Conservador Tradicionalista
+CHL,4634,Q34930858,United Conservative Party,UCP,
+CHL,4644,Q6064022,Democratic Party,,Partido Demócrata
+CHL,390,Q1395049,Christian Democratic Party,,
+CHL,4638,Q5559969,Democratic Party,,Partido Democrático
+CHL,4635,Q6064012,National Democratic Party,,Partido Democrático Nacional
+CHL,7016,Q2354364,Green Ecologist Party,,Partido Ecologista Verde
+CHL,209,Q1312539,Humanist Party,,Partido Humanista
+CHL,7018,Q6064078,Equality Party,,Partido Igualdad
+CHL,8167,Q6016759,Independent Liberal Party,,
+CHL,7984,Q428641,Partido Socialista de Chile,,Izquierda Ciudadana
+CHL,4633,Q3027776,Liberal Party,,Partido Liberal
+CHL,4647,Q3027776,Liberal Party,,Partido Liberal
+CHL,7019,Q3885147,Liberal Party,,Partido Liberal de Chile
+CHL,4646,Q6540628,Liberal Democratic Party,,Partido Liberal Democrático
+CHL,8166,Q7888231,United Liberal Party,,
+CHL,4632,Q3366524,Partido Comunista,,Partido Nacional
+CHL,4649,Q6974790,National Party,,Partido Nacional
+CHL,54,Q1759292,Party for Democracy,,Partido por la Democracia
+CHL,7017,Q6064239,Progressive Party,PRO,Partido Progresista
+CHL,256,Q1759368,Radical Party,,Partido Radical
+CHL,437,Q1549779,Radical Party of Chile,,Partido Radical de Chile
+CHL,4645,Q5843822,Socialist Radical Party,,Partido Radical Socialista
+CHL,1748,Q3896804,Independent Regionalist Party,,Partido Regionalista Independiente
+CHL,6,Q823648,Socialist Party of Chile,,Partido Socialista de Chile
+CHL,4637,Q5858343,Popular Socialist Party,,Partido Socialista Popular
+CHL,7985,Q25934820,Poder,,Poder Ciudadano
+CHL,928,Q1422826,National Renewal,,Renovación Nacional
+CHL,6911,Q6107151,Democratic Revolution,,Revolución Democrática
+CHL,7074,Q15104641,"If You Want It, Chile Changes",,"Si tú quieres, Chile cambia"
+CHL,6119,Q7248821,Progressive Union of the Centrist Center,,Unión de Centro Centro
+CHL,1599,Q602131,Independent Democratic Union,,Unión Demócrata Independiente
+CHN,5124,Q17427,Communist Party of China,CPC/official,中国共产党
+CHN,8372,Q6122192,Progressive Party,,
+CHN,5390,Q31113,Kuomintang,KMT,中國國民黨
+COL,569,Q21001260,Team Colombia,,
+COL,4852,Q1789014,19th of April Movement,,Movimiento 19 de Abril
+COL,5926,Q1452567,Green Party,,Alianza Verde
+COL,8761,Q11680073,Indigenous Authorities of Colombia,,Autoridades Indígenas de Colombia
+COL,561,Q429642,Radical Change,,Cambio Radical
+COL,5879,Q15909095,Democratic Center,,Centro Democrático
+COL,5594,Q7006875,New Democratic Force,,
+COL,6062,Q7009804,New Liberalism,,
+COL,3818,Q3366306,Democratic Colombia Party,,
+COL,1577,Q747333,Colombian Conservative Party,,Partido Conservador Colombiano
+COL,1107,Q2996370,Citizens' Convergence,,
+COL,3817,Q3896853,National Integration Party,,Partido Opción Ciudadana
+COL,362,Q939021,Colombian Liberal Party,,Partido Liberal Colombiano
+COL,8307,Q3366523,National Party (Colombia),,Partido Nacional
+COL,759,Q973542,Social Party of National Unity,,Partido de la Unión por la Gente
+COL,3814,Q3088848,Oxygen Green Party,,
+COL,218,Q2251452,Alternative Democratic Pole,,Polo Democrático Alternativo
+COL,6363,Q1993239,Colombia First,,Primero Colombia
+COL,5115,Q930790,Patriotic Union,,Unión Patriótica
+COM,5297,Q5166253,Convention for the Renewal of the Comoros,,Convention pour le Renouveau des Comores
+COM,8419,Q7223378,Union for the New Republic,,Union pour la nouvelle république
+COM,5712,Q20982167,Juwa Party,,
+COM,5713,Q20982157,Democratic Rally of the Comoros,,
+COM,8423,Q16672202,Democratic Rally of the Comorian People,,
+COM,6582,Q20982190,National Rally for Development,,
+COM,5298,Q20982213,Rally for Democracy and Renewal,,
+COM,7481,Q19946109,Rally for Change and Democracy,,
+COM,5296,Q5155192,Comorian Union for Progress,,اتحاد جزر القمر من أجل التقدم
+COM,7098,Q16681998,Comorian Democratic Union,,
+COM,8420,Q2164587,Democratic and Socialist Union of the Resistance,,Union démocratique et socialiste de la Résistance
+COM,6517,Q20982223,Union for the Development of the Comoros,,
+COM,7483,Q19946160,Realising Freedom's Capability,,
+COG,8401,Q5136089,Club 2002 – Party for the Unity of the Republic,,
+COG,7994,Q4677129,Action and Renewal Movement,MAR,Mouvement Action et Renouveau
+COG,5362,Q3326534,Congolese Movement for Democracy and Integral Development,,Mouvement Congolais pour la Démocratie et le Développement Intégral
+COG,5363,Q6974417,National Movement of the Revolution,,Mouvement national de la révolution
+COG,4723,Q3326838,African Socialist Movement,,
+COG,5365,Q1785816,Congolese Party of Labour,,Parti congolais du travail
+COG,6452,Q5160547,Congolese Progressive Party,,
+COG,5589,Q17075186,Rally for Democracy and Social Progress,,
+COG,8418,Q7287081,Rally for Democracy and Development,,
+COG,5364,Q3550401,Pan-African Union for Social Democracy,UPADS,Union panafricaine pour la démocratie sociale
+COG,8943,Q7886458,Union for Progress,,
+CRI,4882,Q2886561,Partido Alianza Patriótica,,Alianza Patriótica
+CRI,4421,Q6063894,Popular Democratic Action,,
+CRI,7434,Q6156940,Catholic Union (Costa Rica),,
+CRI,8697,Q5794946,21st Century Curridabat,,Curridabat Siglo XXI
+CRI,1252,Q403054,Broad Front,,Partido Frente Amplio
+CRI,4230,Q958971,Democratic Force,,Fuerza Democrática
+CRI,504,Q4672493,Accessibility without Exclusion,,Partido Accesibilidad sin Exclusión
+CRI,5603,Q5164287,Constitutional Party (Costa Rica),,
+CRI,4417,Q15984880,Democratic Party,,
+CRI,4418,Q3366300,National Integration Party,,Partido Integración Nacional
+CRI,1367,Q82591,National Liberation Party,,
+CRI,2363,Q3326706,Libertarian Movement,,Partido Movimiento Libertario
+CRI,842,Q3326706,Libertarian Movement,,Partido Movimiento Libertario
+CRI,8744,Q15984897,New Generation Party,,Partido Nueva Generación
+CRI,864,Q5174899,Costa Rican Renovation Party,,Partido Renovación Costarricense
+CRI,4436,Q6064303,National Republican Party,,Partido Republicano Nacional
+CRI,7724,Q6064303,National Republican Party,,Partido Republicano Nacional
+CRI,8745,Q15984889,Social Christian Republican Party,,Partido Republicano Social Cristiano
+CRI,257,Q6106529,National Restoration Party,,Partido Restauración Nacional
+CRI,1199,Q1056879,Social Christian Unity Party,,Partido Unidad Social Cristiana
+CRI,4422,Q3896654,National Unification Party,,Unificación Nacional
+CRI,161,Q3366267,National Union Party,,Partido Unión Nacional
+CRI,5093,Q2665255,People's Vanguard Party,,
+CRI,7439,Q6064213,Peliquista Party,,Partido Peliquista
+CRI,4881,Q5488980,United People,,Pueblo Unido
+CRI,5117,Q2838019,Unity Coalition,,Coalición Unidad
+CRI,5120,Q4163584,Cartago Agrarian Union Party,,Partido Unión Agrícola Cartaginés
+CRI,4420,Q7886423,Union for Change Party,,
+CIV,5096,Q1422092,Ivorian Popular Front,FPI,Front populaire ivoirien
+CIV,7860,Q3326623,Movement of the Forces of the Future,,
+CIV,8522,Q2723943,Patriotic Movement of Ivory Coast,,Mouvement patriotique de Côte d'Ivoire
+CIV,7335,Q7141131,Party of the French Union of Côte d'Ivoire,,
+CIV,5098,Q1455532,Democratic Party of Côte d'Ivoire – African Democratic Rally,PDCI/RDA,Parti Démocratique de la Côte d'Ivoire — Rassemblement Démocratique Africain
+CIV,8801,Q667415,Ivorian Workers' Party,,Parti ivoirien des travailleurs
+CIV,7607,Q2132038,Rally of Houphouëtists for Democracy and Peace,RHDP,Rassemblement des houphouëtistes pour la démocratie et la paix
+CIV,5097,Q1669673,Rally of the Republicans,RDR,Rassemblement des Républicains
+CIV,7861,Q24228807,Union for Ivory Coast,UPCI,Union pour la Côte d’Ivoire
+CIV,5628,Q3550425,Union for Democracy and Peace in Côte d'Ivoire,UDPCI,Union pour la démocratie et la paix en Côte d'Ivoire
+HRV,5933,Q1249902,Social Democratic Action of Croatia,,Akcija socijaldemokrata Hrvatske
+HRV,5452,Q20648974,Milan Bandić 365 - The Party of Labour and Solidarity,,Bandić Milan 365 – Stranka rada i solidarnosti
+HRV,8606,Q5211529,Dalmatian Action,,Dalmatinska akcija
+HRV,78,Q1270959,Democratic Centre,,Demokratski centar
+HRV,8608,Q21286560,Patriotic Coalition (Croatia),,Domoljubna koalicija
+HRV,8981,Q86756923,Miroslav Škoro Homeland Movement,DP,Domovinski pokret
+HRV,8178,Q39046276,Civic Liberal Alliance,GLAS,Građansko-liberalni savez
+HRV,2029,Q1251816,Croatian Democratic Peasant Party,,Hrvatska demokratska seljačka stranka
+HRV,1431,Q738439,Croatian Democratic Union,HDZ,Hrvatska demokratska zajednica
+HRV,6620,Q1563417,Croatian Civic Party,HGS,Hrvatska građanska stranka
+HRV,5458,Q1055317,Croatian Demochristian Party,HDS,Hrvatska demokršćanska stranka
+HRV,8036,Q1251836,Croatian Christian Democratic Union,,Hrvatska kršćanska demokratska unija
+HRV,799,Q1255803,Croatian People's Party – Liberal Democrats,HNS/LD/HNS,Hrvatska narodna stranka – liberalni demokrati
+HRV,6568,Q5187148,Croatian Popular Party,,
+HRV,72,Q638194,Croatian Peasant Party,HSS,Hrvatska seljačka stranka
+HRV,214,Q1249448,Croatian Social Liberal Party,HSLS,Hrvatska socijalno-liberalna stranka
+HRV,253,Q1257515,Croatian Party of Rights,HSP,Hrvatska stranka prava
+HRV,3142,Q1264421,Croatian Party of Rights 1861,,
+HRV,3706,Q1290995,Croatian Party of Rights dr. Ante Starčević,,Hrvatska stranka prava - dr. Ante Starčević
+HRV,2062,Q1244748,Croatian Party of Pensioners,HSU,Hrvatska stranka umirovljenika
+HRV,1568,Q1277765,Croatian Bloc,,Hrvatski blok
+HRV,2347,Q1262429,Croatian Democratic Alliance of Slavonia and Baranja,HDSSB,Hrvatski demokratski savez
+HRV,3143,Q1274719,Croatian Labourists – Labour Party,,Hrvatski laburisti – Stranka rada
+HRV,3135,Q1251497,Croatian Independent Democrats,,
+HRV,3138,Q5187124,Croatian Growth,HRAST,Hrast-Movement for Successful Croatia
+HRV,7225,Q17662959,Croat-Serb Coalition,,Hrvatsko-srpska koalicija
+HRV,513,Q1261390,Istrian Democratic Assembly,IDS,Istarski demokratski sabor
+HRV,3643,Q1252312,Coalition of People's Accord,,
+HRV,4078,Q1268048,League of Communists of Croatia,,Savez komunista Hrvatske
+HRV,2522,Q96785149,Restart Coalition,,
+HRV,381,Q1278787,Liberal Party,LS,Liberalna stranka
+HRV,4868,Q2678618,Međimurje Party,,
+HRV,4865,Q16116415,Bridge of Independent Lists,Most,Most
+HRV,8980,Q96099072,We can!,,Možemo! – politička platforma
+HRV,7222,Q1563411,People's Party,,Narodna stranka
+HRV,4866,Q18166661,People's Party - Reformists,NS/R,Narodna stranka – Reformisti
+HRV,8284,Q4863685,People's Front of Yugoslavia,,
+HRV,7422,Q39176429,Independents for Croatia,,Neovisni za Hrvatsku
+HRV,3201,Q15953679,Croatian Sustainable Development,,Zelena alternativa - Održivi razvoj Hrvatske
+HRV,7336,Q30324660,Pametno,,Centar
+HRV,3109,Q7197808,Pirate Party Croatia,,Piratska stranka
+HRV,3133,Q1277134,Alliance of Primorje-Gorski Kotar,,Primorsko-goranski savez
+HRV,2348,Q1261401,Independent Democratic Serb Party,SDSS,Samostalna demokratska srpska stranka
+HRV,8037,Q1251772,Slavonia-Baranja Croatian Party,,
+HRV,1475,Q830323,Social Democratic Party of Croatia,SDP,Socijaldemokratska partija Hrvatske
+HRV,5934,Q1564938,Left of Croatia,,Ljevica Hrvatske
+HRV,2525,Q1276969,Serb People's Party,,Srpska narodna stranka
+HRV,7228,Q1564395,Serb People's Independent Party,,
+HRV,2502,Q1276894,Party of Democratic Action of Croatia,,Stranka demokratske akcije Hrvatske
+HRV,7221,Q1250281,Party of Rights,,Stranka prava
+HRV,8283,Q151179,Ustaše,,Ustaša –
+HRV,4867,Q16117007,Human Blockade,ŽZ,Živi zid
+CUB,6823,Q48783116,ABC,,
+CUB,8380,Q218452,26th of July Movement,,Movimiento 26 de Julio
+CUB,4892,Q371402,Communist Party of Cuba,,Partido Comunista de Cuba
+CUB,6830,Q65083342,National Conservative Party,PCN,Partido Conservador Nacional
+CUB,6437,Q15980912,Progressive Action Party,PAP,Partido de Acción Progresista
+CUB,6825,Q1525551,Party of the Cuban People – Orthodox,,Partido Ortodoxo
+CUB,4727,Q56276455,Democratic Party,PD,Partido Demócrata
+CUB,4725,Q2881637,Liberal Party of Cuba,PLC,Partido Liberal de Cuba
+CUB,6257,Q5192030,Cuban National Party,,Partido Nacional Cubano
+CUB,6829,Q65083337,Cuban Popular Party,PPC,Partido Popular Cubano
+CUB,6255,Q7314645,Republican Party of Havana,,Partido Republicano de La Habana
+CUB,4726,Q32752,Partido Auténtico,,
+CUB,4659,Q1778910,Popular Socialist Party,PSP,Partido Socialista Popular
+CUB,7099,Q5255842,Democratic Union Party,,Partido Unión Democrática
+CUW,6925,Q5470578,Forsa Kòrsou,,
+CUW,3804,Q2712780,Movement for the Future of Curaçao,,Movementu Futuro Kòrsou
+CUW,3809,Q1269032,Real Alternative Party,PAR,Partido Alternativa Real
+CUW,6926,Q2212488,Democratic Party,,Partido Democraat
+CUW,3811,Q2485229,Party Workers' Liberation Front 30th of May,,Frente Obrero Liberashon
+CUW,6927,Q2455126,People's Crusade Labour Party,,Partido Laboral Krusada Popular
+CUW,3806,Q2370694,Partido MAN,,Partido MAN
+CUW,3805,Q2487652,National People's Party,,
+CUW,3807,Q7140560,Partido pa Adelanto I Inovashon Soshal,,
+CUW,3803,Q2224802,Sovereign People,,
+CYP,1076,Q212158,Progressive Party of Working People,AKEL,Ανορθωτικό Κόμμα Εργαζόμενου Λαού
+CYP,6332,Q6089355,Peace and Democracy Movement,,
+CYP,6109,Q731357,Republican Turkish Party,,Cumhuriyetçi Türk Partisi
+CYP,7412,Q15980827,Democratic National Party (Cyprus),,Δημοκρατικό Eθνικό Kόμμα
+CYP,6199,Q833597,Democratic Party,,Demokrat Parti
+CYP,635,Q816863,Democratic Party,DIKO,Δημοκρατικό Κόμμα
+CYP,563,Q644973,Democratic Rally,DISY,Δημοκρατικός Συναγερμός
+CYP,4894,Q3563375,Eniaion,,Eniaion
+CYP,321,Q930328,United Democrats,,Ενωμένοι Δημοκράτες
+CYP,1013,Q2748384,ELAM,ELAM,
+CYP,697,Q3043538,European Democracy,,
+CYP,1817,Q927007,European Party,,Ευρωπαϊκό Κόμμα
+CYP,4883,Q24045777,Solidarity Movement,,Κίνημα Αλληλεγγύη
+CYP,858,Q1650110,Movement of Ecologists — Citizens' Cooperation,,Κίνημα Οικολόγων – Συνεργασία Πολιτών
+CYP,1028,Q259800,Movement for Social Democracy,EDEK,Κίνημα Σοσιαλδημοκρατών
+CYP,6108,Q1809278,National Unity Party,,Ulusal Birlik Partisi
+CYP,6197,Q307881,Freedom and Reform Party,,Özgürlük ve Reform Partisi
+CYP,4893,Q16962955,Patriotic Front,,Πατριωτικό Μέτωπο
+CYP,7411,Q16967783,Progressive Front,,
+CYP,6198,Q836954,Communal Democracy Party,,Toplumcu Demokrasi Partisi
+CYP,6201,Q5153952,Communal Liberation Party,,
+CZE,2141,Q10728124,ANO 2011,,ANO 2011
+CZE,5610,Q699659,Farmers' League,,Bund der Landwirte
+CZE,2047,Q341085,Czech Pirate Party,Piráti,Česká pirátská strana
+CZE,5244,Q341111,Czech National Social Party,,Česká strana národně sociální
+CZE,177,Q341148,Czech Social Democratic Party,ČSSD,Česká strana sociálně demokratická
+CZE,5777,Q2565151,Czechoslovak National Democracy,ČsND,Československá národní demokracie
+CZE,5236,Q341148,Czech Social Democratic Party,ČSSD,Česká strana sociálně demokratická
+CZE,5549,Q1142687,KDU-ČSL,,
+CZE,5611,Q11178881,Czechoslovak Traders' Party,,
+CZE,6202,Q8565041,Four-Coalition,,Čtyřkoalice
+CZE,1171,Q11774575,Democratic Union,,
+CZE,6292,Q1202282,German Christian Social People's Party,,Deutsche Christlich-Soziale Volkspartei
+CZE,6294,Q456307,German Social Democratic Workers Party in the Czechoslovak Republic,,Deutsche sozialdemokratische Arbeiterpartei in der Tschechoslowakischen Republik
+CZE,670,Q21534275,Pensioners for Life Security,,Strana za životní jistoty
+CZE,165,Q682368,European Democratic Party,,Evropská demokratická strana
+CZE,7337,Q62029792,Voice,Hlas,Hlas
+CZE,6293,Q693985,Slovak People's Party,,Hlinkova slovenská ľudová strana –
+CZE,952,Q2597822,Movement for Autonomous Democracy–Party for Moravia and Silesia,,Hnutí za samosprávnou demokracii - Společnost pro Moravu a Slezsko
+CZE,5245,Q285694,Hungarian-German Social Democratic Party,,
+CZE,2142,Q3565836,Club of Committed Non-Party Members,,Klub angažovaných nestraníků
+CZE,1728,Q913567,Communist Party of Bohemia and Moravia,,Komunistická strana Čech a Moravy
+CZE,1041,Q727724,Communist Party of Czechoslovakia,,Komunistická strana Československa
+CZE,6798,Q1751122,Communist Party of Slovakia,,Komunistická strana Slovenska
+CZE,676,Q1142687,KDU-ČSL,,
+CZE,824,Q5109507,Christian Democratic Party,,Křesťanskodemokratická strana
+CZE,1813,Q341111,Czech National Social Party,,Česká strana národně sociální
+CZE,1127,Q1347192,Řád národa,,Řád národa
+CZE,6468,Q12041663,National Unification,,Národní sjednocení
+CZE,8523,Q3790505,National Partnership,NS,
+CZE,6796,Q567306,German National Socialist Workers' Party,,Deutsche Nationalsozialistische Arbeiterpartei
+CZE,1008,Q1807830,Civic Democratic Alliance,,
+CZE,466,Q828099,Civic Democratic Party,ODS,Občanská demokratická strana
+CZE,1349,Q1755236,Civic Forum,,
+CZE,1796,Q3565827,Party for the Open Society,,Strana pro otevřenou společnost
+CZE,8109,Q7252621,Provincial Christian-Socialist Party,OKSZP,Országos Keresztényszocialista Párt
+CZE,972,Q2655581,Republicans of Miroslav Sládek,,Sdružení pro republiku –  Republikánská strana Československa
+CZE,5246,Q2568847,Republican Party of Agricultural and Smallholder People,,
+CZE,1657,Q2655581,Republicans of Miroslav Sládek,,Sdružení pro republiku –  Republikánská strana Československa
+CZE,751,Q2165477,SNK European Democrats,,SNK Evropští demokraté
+CZE,1707,Q1586610,Mayors and Independents,STAN,Starostové a nezávislí
+CZE,8229,Q1267256,Party of National Unity,SNJ,Strana národní jednoty
+CZE,1272,Q176956,Party of Civic Rights,SPO,Strana Práv Občanů
+CZE,254,Q164878,Party of Free Citizens,,Svobodní
+CZE,8923,Q13434915,Party of Common Sense,,Strana zdravého rozumu
+CZE,1554,Q631218,Green Party,,Strana&nbsp;zelených
+CZE,5237,Q678584,Sudeten German Party,,Sudetendeutsche Partei
+CZE,293,Q1118700,Czech Sovereignty,SBB,Volný blok
+CZE,6125,Q20058756,Freedom and Direct Democracy,,Svoboda a přímá demokracie
+CZE,223,Q651129,TOP 09,,
+CZE,905,Q2296356,Freedom Union – Democratic Union,,
+CZE,104,Q2296356,Freedom Union – Democratic Union,,
+CZE,2049,Q14923603,Dawn of Direct Democracy,,Úsvit – Národní koalice
+CZE,1202,Q1784683,Public Affairs,,Věci veřejné
+CZE,6305,Q294592,Public Against Violence,,
+DNK,4070,Q18042964,The Alternative,,Alternativet
+DNK,1901,Q3777440,Farmers' Party,,
+DNK,800,Q1054386,Centre Democrats,CD,Centrum-Demokraterne
+DNK,277,Q1164324,Communist Party of Denmark,,Danmarks Kommunistiske Parti
+DNK,1900,Q707428,National Socialist Workers' Party of Denmark,DNSAP,Danmarks Nationalsocialistiske Arbejderparti
+DNK,1022,Q507170,Danish People's Party,DF,Dansk Folkeparti
+DNK,637,Q5219816,Danish Unity,,
+DNK,112,Q3502880,De Grønne,,
+DNK,1507,Q916161,Danish Social Liberal Party,,Radikale Venstre
+DNK,932,Q1798258,Independent Party,,De Uafhængige
+DNK,1527,Q25785,Red–Green Alliance,Ø,Enhedslisten – De Rød-Grønne
+DNK,1912,Q10480355,Industry Party,,Erhvervspartiet
+DNK,1676,Q3355611,Common Course,,Fælles Kurs
+DNK,333,Q1435460,People's Movement against the EU,,Folkebevægelsen mod EU
+DNK,1601,Q1455237,Progress Party,FrP,Fremskridtspartiet
+DNK,8174,Q1252927,Højre,,
+DNK,1421,Q1713509,June Movement,,JuniBevægelsen
+DNK,536,Q902619,Conservative People's Party,K,Det Konservative Folkeparti
+DNK,53,Q1789199,Christian Democrats,,Kristendemokraterne
+DNK,7339,Q23014672,Nye Borgerlige,,Nye Borgerlige
+DNK,212,Q478180,Liberal Alliance,LA,
+DNK,1134,Q3771782,Justice Party of Denmark,,Retsforbundet
+DNK,6651,Q571175,Siumut,,Siumut
+DNK,1200,Q460139,Schleswig Party,,
+DNK,379,Q212101,Social Democracy,A,Socialdemokratiet
+DNK,329,Q615603,Socialist People's Party,SF,Socialistisk Folkeparti
+DNK,7338,Q48215025,Stram Kurs,,Stram Kurs
+DNK,1204,Q217321,Venstre,V,"Venstre, Danmarks Liberale Parti"
+DNK,1136,Q2569870,Left Socialists,VS,Venstresocialisterne
+DJI,6244,Q1470091,Front for the Restoration of Unity and Democracy,,Front pour la Restauration de l'Unité et de la Démocratie
+DJI,5151,Q15975477,Movement for Democratic Renewal and Development,,Mouvement pour le Renouveau Démocratique et le Développement
+DJI,8428,Q3366379,Party of the Popular Movement,,
+DJI,5148,Q3366531,National Democratic Party,,
+DJI,7811,Q7550596,Social Democratic People's Party,,
+DJI,5125,Q1817797,People's Rally for Progress,,
+DJI,7812,Q7886698,Union of Reform Partisans,,
+DJI,7543,Q1538413,Union for the Presidential Majority,UMP,Union pour la Majorité Présidentielle
+DJI,8809,Q15980848,Union for National Salvation,,Union pour le Salut National
+DJI,7235,Q7314716,Republican Union,,
+DMA,3746,Q1254046,Dominica Freedom Party,,
+DMA,3744,Q1287573,Dominica Labour Party,,
+DMA,3745,Q1253956,United Workers' Party,,
+DOM,5948,Q28455046,Alternative Democratic Movement,MODA,
+DOM,1225,Q2511535,Dominican Liberation Party,PLD,Partido de la Liberación Dominicana
+DOM,4728,Q3366373,Dominican Party,PD,Partido Dominicano
+DOM,4195,Q25406051,Quisqueyano Christian Democratic Party,,
+DOM,7429,Q2153476,Social Christian Reformist Party,PRSC,Partido Reformista Social Cristiano
+DOM,194,Q2153476,Social Christian Reformist Party,PRSC,Partido Reformista Social Cristiano
+DOM,1441,Q31284,Dominican Revolutionary Party,PRD,Partido Revolucionario Dominicano
+DOM,7544,Q17515858,Modern Revolutionary Party,PRM,Partido Revolucionario Moderno
+DOM,8346,Q15980741,Los Coludos,,Partido Rojo
+COD,8416,Q2367261,Alliance of Democratic Forces for the Liberation of Congo,AFDL,Alliance des Forces Démocratiques pour la Libération du Congo-Zaïre
+COD,5772,Q1666735,ABAKO,ABAKO,Alliance des Bakongo
+COD,8944,Q2838235,Alliance of the Presidential Majority,,
+COD,6588,Q2388990,CONAKAT,,Confédération des Associations tribales du Katanga
+COD,6208,Q5467563,Forces for Renewal,,Forces du Renouveau
+COD,7426,Q1856755,Mouvement National Congolais,,Mouvement National Congolais
+COD,6050,Q1856755,Mouvement National Congolais,,Mouvement National Congolais
+COD,5091,Q1670999,Partie de l'unité nationale,MPR,Mouvement populaire de la Révolution
+COD,5089,Q144806,Movement for the Liberation of the Congo,,Mouvement de libération du Congo
+COD,5598,Q3326837,Social Movement for Renewal,,Mouvement Social pour le Renouveau
+COD,8947,Q3366279,National Alliance Party for Unity,,
+COD,5090,Q1235589,People's Party for Reconstruction and Democracy,,Parti du Peuple pour la Reconstruction et la Démocratie
+COD,5597,Q3087061,Ensemble pour la république,,Parti Lumumbiste Unifié
+COD,6453,Q7140305,Parti Solidaire Africain,,
+COD,8946,Q1498659,Rally for Congolese Democracy,,Rassemblement Congolais pour la Démocratie
+COD,8414,Q3550150,Union of Federalists and Independent Republicans,,
+COD,5092,Q1629663,Union for Democracy and Social Progress,,
+COD,6063,Q3550434,Union for the Congolese Nation,,Union pour la nation congolaise
+ECU,4044,Q289078,PAÍS Alliance,,Movimiento Alianza PAIS (Patria Altiva i Soberana)
+ECU,4348,Q1123742,Concentration of People's Forces,,Concentración de Fuerzas Populares
+ECU,4198,Q1455526,Alfarista Radical Front,,
+ECU,8614,Q22921285,Fuerza Ecuador,,Fuerza Ecuador
+ECU,797,Q915562,Democratic Left,ID,
+ECU,4269,Q3894843,CREO,CREO,Creando Oportunidades (CREO)
+ECU,827,Q1972741,Pachakutik Plurinational Unity Movement – New Country,MUPP,Movimiento de Unidad Plurinacional Pachakutik – Nuevo País
+ECU,4203,Q2136126,Ethics and Democracy Network,,
+ECU,7487,Q1815140,Communist Party of Ecuador,,Partido Comunista del Ecuador
+ECU,4349,Q1523085,Conservative Party,,Partido Conservador Ecuatoriano
+ECU,4270,Q2054656,Radical Liberal Party,,Partido Liberal Radical Ecuatoriano
+ECU,1131,Q1425186,Institutional Renewal Party of National Action,,
+ECU,1450,Q580666,Ecuadorian Roldosist Party,,Partido Roldosista Ecuatoriano
+ECU,950,Q499377,Social Christian Party,PSC,Partido Social Cristiano
+ECU,246,Q570082,Patriotic Society,PSP,Partido Sociedad Patriótica
+ECU,8320,Q21706132,Progresistas,,Progresistas
+ECU,885,Q2054814,Ecuadorian Socialist Party,PSE,Partido Socialista Ecuatoriano
+ECU,1405,Q913715,Popular Democracy,,Unión Demócrata Cristiana
+EGY,8038,Q253911,Egyptian Social Democratic Party,,الحزب المصرى الديمقراطى الاجتماعى
+EGY,2371,Q133207,Society of the Muslim Brothers,,جماعة الإخوان المسلمين
+EGY,5153,Q624111,Arab Socialist Union,,الاتحاد الاشتراكى العربى
+EGY,6210,Q254009,Egyptian Bloc,,الكتلة المصرية
+EGY,5871,Q962942,Free Egyptians Party,,حزب المصريين الأحرار
+EGY,6289,Q286519,El-Ghad Party,,Hizb el-Ghad
+EGY,6508,Q743164,Liberal Constitutional Party,,حزب الاحرار الدستوريين
+EGY,2370,Q841133,National Democratic Party,,الحزب الوطني الديمقراطي
+EGY,5129,Q685715,Freedom and Justice Party,,حزب الحرية و العدالة
+EGY,5128,Q210461,Al-Nour Party,,حزب النور
+EGY,6506,Q748617,Wafd Party,,حزب الوفد
+EGY,2303,Q767012,New Wafd Party,,حزب الوفد المصري
+EGY,7107,Q402650,Liberal Socialists Party,,Hizb al-Ahrar al-Ishtirakin
+EGY,6209,Q253725,Egyptian Islamic Labour Party,,حزب العمل الاسلامي
+EGY,8112,Q19895457,Ittihad Party,,حزب الاتحاد
+EGY,6930,Q20982186,Nation's Future Party,,حزب مستقبل وطن
+EGY,6507,Q12186375,Saadist Institutional Party,,حزب الهيئة السعدية
+EGY,2372,Q1966909,National Progressive Unionist Party,,حزب التجمع الوطني التقدمي الوحدوي
+EGY,8111,Q3896783,Watani Party,,ﺍﻟﺤﺰﺐ ﺍﻟﻮﻃﻨﻲ
+SLV,1709,Q1146480,Nationalist Republican Alliance,ARENA,Alianza Republicana Nacionalista
+SLV,1456,Q2728438,Democratic Change,,Cambio Democrático
+SLV,978,Q648924,Farabundo Martí National Liberation Front,FMLN,Frente Farabundo Martí para la Liberación Nacional
+SLV,4224,Q5594236,Grand Alliance for National Unity,GANA,Gran Alianza por la Unidad Nacional
+SLV,8085,Q57986086,NI,N/NI,Nuevas Ideas
+SLV,686,Q1123900,National Coalition Party,PCN,Partido de Concertación Nacional
+SLV,11,Q1953774,Christian Democratic Party,,Partido Demócrata Cristiano
+SLV,6302,Q28404587,National Pro Patria Party,,Partido Nacional Pro-Patria
+SLV,4730,Q7318830,Revolutionary Party of Democratic Unification,,
+SLV,4903,Q104850252,National Opposing Union,UNO,Unión Nacional Opositora
+GNQ,3821,Q2996391,Convergence for Social Democracy,,Convergencia Para la Democracia Social
+GNQ,6249,Q9006697,Popular Idea of Equatorial Guinea,,Idea Popular de Guinea Ecuatorial
+GNQ,3824,Q945167,Democratic Party of Equatorial Guinea,PDGE,Partido Democrático de Guinea Ecuatorial
+GNQ,6367,Q1606430,United National Workers' Party,PUNT,Partido Único Nacional de los Trabajadores
+GNQ,6454,Q2996391,Convergence for Social Democracy,,Convergencia Para la Democracia Social
+GNQ,6064,Q18618907,Popular Union of Equatorial Guinea,,
+ERI,8431,Q889543,Eritrean People's Liberation Front,,
+ERI,4904,Q863376,People's Front for Democracy and Justice,PFDJ,ህዝባዊ ግንባር ንደሞክራስን ፍትሕን
+ERI,8432,Q5152650,Commission for Organizing the Party of the Working People of Ethiopia,,የኢትዮጵያ ሰራተኞች ፓርቲ አደራጅ ኮሚሽን
+EST,5142,Q15694556,Settlers' Party,,
+EST,6803,Q79854,Communist Party of the Soviet Union,CPSU/KPSS,
+EST,8114,Q583290,German-Baltic Party,,
+EST,6709,Q12361229,Estonian Independent Socialist Workers' Party,,
+EST,8922,Q1370352,Estonian Independence Party,,Eesti Iseseisvuspartei
+EST,533,Q928652,Estonian Centre Party,KESK,Eesti Keskerakond
+EST,4094,Q794028,Conservative People's Party of Estonia,EKRE,Eesti Konservatiivne Rahvaerakond
+EST,1556,Q1370312,Estonian Coalition Party,,
+EST,790,Q1295599,Party of Estonian Christian Democrats,,Erakond Eesti Kristlikud Demokraadid
+EST,8705,Q5401568,Estonian Liberal Democratic Party,,
+EST,7238,Q1633891,Communist Party of Estonian Soviet Socialist Republic,,Eestimaa Kommunistlik Partei
+EST,174,Q774470,People's Union of Estonia,EME,Eestimaa Rahvaliit
+EST,110,Q774470,People's Union of Estonia,EME,Eestimaa Rahvaliit
+EST,5144,Q991414,Estonian People's Party,,Eesti Rahvaerakond
+EST,5155,Q16835726,Estonian Democratic Party,,
+EST,1299,Q2634590,Estonian National Independence Party,,
+EST,821,Q738947,Estonian Reform Party,RE,Eesti Reformierakond
+EST,5850,Q12361438,Estonian Greens,EER,Erakond Eestimaa Rohelised
+EST,1973,Q6541457,Libertas Estonia,,Libertas Eesti Erakond
+EST,7244,Q3366717,Estonian Social Democratic Workers' Party,,Eesti Sotsiaaldemokraatiline Tööliste Partei
+EST,869,Q3896845,Estonian Left Party,,Eesti Vasakpartei
+EST,5157,Q12361449,Estonian Socialist Revolutionary Party,,
+EST,5156,Q285035,Estonian Labour Party,,
+EST,3271,Q19276353,Estonian Free Party,EVA,Eesti Vabaerakond
+EST,3692,Q3896845,Estonian Left Party,,Eesti Vasakpartei
+EST,7341,Q60523058,Biodiversity Party,,Elurikkuse Erakond
+EST,7340,Q56249403,Estonia 200,,Erakond Eesti 200
+EST,685,Q163347,Isamaa,I,
+EST,1040,Q1295694,Estonian Greens,EER,Erakond Eestimaa Rohelised
+EST,7242,Q15958430,Estonian Radical Socialist Party,,
+EST,7239,Q12364669,Patriotic League (Estonia),,Isamaaliit
+EST,779,Q1428217,Pro Patria Union,,Isamaaliit
+EST,18,Q652831,Constitution Party,,Konstitutsioonierakond
+EST,7466,Q1650899,Christian People's Party,,
+EST,5140,Q2120649,Farmers' Assemblies,,Põllumeeste Kogud
+EST,331,Q599281,Popular Front of Estonia,,
+EST,5135,Q2127493,National Centre Party,,Rahvuslik Keskerakond
+EST,908,Q3896837,National Coalition Party Pro Patria,,
+EST,7241,Q17098891,Social Travaillist Party,,
+EST,1150,Q913551,Social Democratic Party,SDE,Sotsiaaldemokraatlik Erakond
+EST,429,Q1370352,Estonian Independence Party,,Eesti Iseseisvuspartei
+EST,491,Q1471814,Res Publica Party,,Erakond Res Publica
+EST,1975,Q1814309,Russian Party in Estonia,,
+ETH,4326,Q382122,Afar National Democratic Party,,
+ETH,5827,Q1966902,Amhara Democratic Party,ADP,አማራ ዴሞክራሲያዊ ፓርቲ
+ETH,4327,Q817331,Benishangul-Gumuz People's Democratic Unity Front,,
+ETH,4323,Q1376302,Coalition for Unity and Democracy,,ቅንጅት ለአንድነት እና ዴሞክራሲ
+ETH,4322,Q1145280,Ethiopian People's Revolutionary Democratic Front,,የኢትዮጵያ ሕዝቦች አብዮታዊ ዲሞክራሲያዊ ግንባር
+ETH,5629,Q549703,Medrek,,መድረክ
+ETH,5836,Q1186219,Oromo Democratic Party,ODP,Paartii Demokraatawaa Oromoo
+ETH,4321,Q766610,Somali People's Democratic Party,,የሶማሌ ዴሞክራሲዊ ፓርቲ
+ETH,6589,Q1186157,Southern Ethiopian People's Democratic Movement,SEPDM,ደቡብ ኢትዮጵያ ህዝቦች ዴሞክራሲያዊ ንቅናቄ
+ETH,5843,Q1699287,Tigray People's Liberation Front,TPLF,ህዝባዊ ወያነ ሓርነት ትግራይ
+ETH,4324,Q491145,United Ethiopian Democratic Forces,,የኢትዮጵያ ዴሞክራሲዊ ኃይሎቸ ሕብረት
+ETH,8434,Q5152650,Commission for Organizing the Party of the Working People of Ethiopia,,የኢትዮጵያ ሰራተኞች ፓርቲ አደራጅ ኮሚሽን
+ETH,5793,Q627213,Workers' Party of Ethiopia,,የኢትዮጵያ ሠራተኞች ፓርቲ
+EUN,6401,Q1517887,Alliance of Liberals and Democrats for Europe,,Alliance des Démocrates et des Libéraux pour l'Europe
+EUN,6400,Q1345559,European Conservatives and Reformists,ECR,
+EUN,6398,Q208242,European People's Party,EPP,European People's Party
+EUN,6402,Q753711,European United Left–Nordic Green Left,GUE/NGL,
+EUN,6404,Q1165759,Europe of Freedom and Direct Democracy,EFDD,
+EUN,8759,Q617060,"Identity, Tradition, Sovereignty",ITS,
+EUN,6399,Q507343,Progressive Alliance of Socialists and Democrats,S/D,
+EUN,6403,Q751935,The Greens–European Free Alliance,Greens/EFA,
+EUN,8760,Q835545,Union for Europe of the Nations,UEN,
+FRO,5522,Q10996859,Workers' Union,,
+FRO,5530,Q591023,Progress,,Framsókn
+FRO,5527,Q932342,People's Party,,Hin føroyski fólkaflokkurin – radikalt sjálvstýri
+FRO,5524,Q856027,Social Democratic Party of the Faroe Islands,JF,Javnaðarflokkurin
+FRO,6179,Q1814426,Christian People's Party,,
+FRO,5526,Q728693,Centre Party,,Miðflokkurin
+FRO,5528,Q932374,New Self-Government,,Sjálvstýri
+FRO,5529,Q932400,Union Party,,Sambandsflokkurin
+FRO,5523,Q750962,Republic,,Tjóðveldi
+FRO,5525,Q7932674,Vinnuflokkurin,,
+FJI,6214,Q5448188,Fijian Nationalist Party,,
+FJI,5795,Q17069868,Fiji First Party,,
+FJI,4887,Q612939,Fiji Labour Party,FLP,
+FJI,5893,Q5163020,Conservative Alliance,,
+FJI,4888,Q6972579,National Federation Party,NFP,
+FJI,8706,Q7009720,New Labour Unity Party,,
+FJI,5884,Q17064859,Fiji Labour Party,,
+FJI,5794,Q7550539,Social Democratic Liberal Party,SODELPA,
+FJI,4890,Q640308,Soqosoqo Duavata ni Lewenivanua,SDL,Soqosoqo Duavata ni Lewenivanua
+FJI,8746,Q55075151,Unity Fiji Party,UFP,
+FJI,7470,Q5109501,Christian Democratic Alliance,,
+FIN,166,Q540982,Democratic Alternative,DeVa,
+FIN,725,Q1442516,Patriotic People's Movement,IKL,Isänmaallinen kansanliike
+FIN,1862,Q1191102,National Progressive Party,,Kansallinen Edistyspuolue
+FIN,495,Q304191,National Coalition Party,KOK,
+FIN,1223,Q10480674,Kirjava ”Puolue” – Elonkehän Puolesta,KiPu,
+FIN,703,Q1138982,Christian Democrats,KD,Kristillisdemokraatit
+FIN,249,Q613849,Liberals,LKP,Liberaalinen Kansanpuolue
+FIN,8639,Q52157683,Liike Nyt,,Liike Nyt
+FIN,901,Q506591,Centre Party,Kesk,Suomen Keskusta
+FIN,1905,Q1713433,Young Finnish Party,,Nuorsuomalainen Puolue
+FIN,856,Q8058120,Young Finns,Nusu,Nuorsuomalaiset
+FIN,414,Q5164311,Constitutional Right Party,POP,Perustuslaillinen oikeistopuolue
+FIN,1962,Q1336715,Small Farmers Party,PMP,
+FIN,250,Q15117358,Reform Group (Finland),Rem,
+FIN,1229,Q845537,Swedish People's Party of Finland,RKP,Svenska folkpartiet i Finland
+FIN,3202,Q1854411,Finnish Rural Party,SMP,Suomen Maaseudun Puolue
+FIN,3684,Q1378704,Finnish Party,,
+FIN,1096,Q585735,Finnish People's Democratic League,SKDL,
+FIN,3688,Q1628434,People's Party of Finland,KP,
+FIN,372,Q5450807,Finnish People's Unity Party,SKYP,Suomen Kansan Yhtenäisyyden Puolue
+FIN,7030,Q385665,Communist Party of Finland,SKP,
+FIN,1904,Q220217,Socialist Workers' Party of Finland,SSTP,Suomen Sosialistinen Työväenpuolue
+FIN,806,Q1458042,Small Farmers' Party of Finland,SPP,
+FIN,1689,Q634277,Finns Party,PS,Perussuomalaiset
+FIN,1303,Q499029,Social Democratic Party of Finland,SDP,Suomen Sosiaalidemokraattinen Puolue
+FIN,1164,Q1813319,Social Democratic Union of Workers and Smallholders,TPSL,
+FIN,5859,Q30337076,Blue Reform,,Sininen tulevaisuus
+FIN,488,Q914375,Liberal League,VL,
+FIN,1044,Q385927,Left Alliance,vas,Vasemmistoliitto
+FIN,479,Q196695,Green League,Vihr,Vihreä liitto
+FRA,3105,Q2151209,Popular Liberal Action,,Action libérale populaire
+FRA,1177,Q762083,Centrist Alliance,,Alliance centriste
+FRA,399,Q2037506,Democratic Centre,CD,Centre Démocrate
+FRA,288,Q2945578,"Centre, Democracy and Progress",,Centre démocratie et progrès
+FRA,3155,Q1054196,Centre of Social Democrats,CDS,Centre des démocrates sociaux
+FRA,1629,Q761433,National Centre of Independents and Peasants,CNIP,Centre national des indépendants et paysans
+FRA,6422,Q2150640,Republican Centre,,
+FRA,1313,Q1070371,Rurality Movement,CPNT,
+FRA,3207,Q12962,France Arise,DLR,
+FRA,4364,Q686372,Liberal Democracy,,Démocratie libérale
+FRA,5746,Q2531463,Doctrinaires,,Doctrinaires
+FRA,5650,Q613786,Europe Ecology – The Greens,EELV,Europe Écologie Les Verts
+FRA,4626,Q179456,Republican Federation,,Fédération républicaine
+FRA,4363,Q29348702,Left Front (France),FDG,Front de gauche
+FRA,433,Q205150,National Rally,RN,Rassemblement national
+FRA,8115,Q3099354,Social and Radical Left,,
+FRA,1273,Q1153753,Ecology Generation,GÉ,Génération écologie
+FRA,7342,Q31400965,Génération.s,G/s,
+FRA,5858,Q27978402,Unsubmissive France,FI/LFI,La France insoumise
+FRA,5857,Q23731823,La République En Marche,EM,La République en marche !
+FRA,5744,Q877884,Legitimism,,Légitimistes
+FRA,8168,Q20012759,The Republicans,LR,Les Républicains
+FRA,1108,Q743390,The Greens,,Les Verts
+FRA,1506,Q862627,Revolutionary Communist League,,
+FRA,6712,Q846469,Ligue des Patriotes,,Ligue des Patriotes
+FRA,5514,Q7223378,Union for the New Republic,,Union pour la nouvelle république
+FRA,617,Q870667,Lutte Ouvrière,,Lutte ouvrière
+FRA,496,Q587370,Democratic Movement,MoDem,Mouvement démocrate
+FRA,3156,Q1321802,Citizen and Republican Movement,,Mouvement républicain et citoyen
+FRA,1634,Q1469596,National Republican Movement,MNR,
+FRA,364,Q870654,Movement for France,MPF,Mouvement pour la France
+FRA,167,Q3326823,Reforming Movement,,
+FRA,737,Q1236315,Popular Republican Movement,MRP,Mouvement Républicain Populaire
+FRA,1255,Q853418,Les Centristes,NC,Les Centristes
+FRA,6684,Q1045425,New Anticapitalist Party,NPA,Nouveau Parti anticapitaliste
+FRA,5743,Q431192,Orléanism,,Orléanistes
+FRA,7343,Q27867942,Animalist Party,,Parti animaliste
+FRA,1251,Q192821,French Communist Party,PCF,Parti communiste français
+FRA,8359,Q922707,Left Party,PG,Parti de Gauche
+FRA,3107,Q2697626,Popular Democratic Party,,Parti démocrate populaire
+FRA,8921,Q20927529,Ecologist Party,,Parti écologiste
+FRA,1783,Q427965,Radical Party of the Left,PRG,Parti radical de Gauche
+FRA,14,Q1542710,Radical Party,,Parti radical
+FRA,1473,Q1820941,Republican Party of Liberty,,Parti républicain de la liberté
+FRA,3102,Q2095948,Republican-Socialist Party,,Parti républicain-socialiste
+FRA,6689,Q3366713,Social Democratic Party,,
+FRA,1478,Q170972,Socialist Party,PS,Parti socialiste
+FRA,912,Q862828,Unified Socialist Party,,Parti socialiste unifié
+FRA,8042,Q2132031,Rally of the French People,,Rassemblement du peuple français
+FRA,509,Q1052584,Rally for the Republic,RPR,Rassemblement pour la République
+FRA,1246,Q2300622,Independent Republicans,,Républicains Indépendants
+FRA,8221,Q3318180,Opportunist Republicans,,Républicains opportunistes
+FRA,4627,Q3456354,Progressive Republicans,,Républicains progressistes
+FRA,4785,Q1332068,French Section of the Workers' International,СФИО,Section française de l'Internationale ouvrière
+FRA,5745,Q2526084,Ultra-royalist,,Ultraroyalistes
+FRA,1580,Q28154294,Union for the Defense of Tradesmen and Artisans,UDCA,
+FRA,2470,Q2164587,Democratic and Socialist Union of the Resistance,,Union démocratique et socialiste de la Résistance
+FRA,3229,Q82892,Union of Democrats and Independents,UDI,Union des démocrates et indépendants
+FRA,8041,Q1904825,Union of Democrats for the Republic,,Union des Démocrates pour la République
+FRA,2537,Q3550144,Union of the Democratic Forces,,
+FRA,7344,Q7030472,Popular Republican Union,UPR,Union Populaire Républicaine
+FRA,213,Q827415,Union for French Democracy,UDF,Union pour la démocratie française
+FRA,1595,Q173152,Union for a Popular Movement,UMP,Union pour un mouvement populaire
+FRA,3159,Q2344776,Democratic Republican Alliance,,Alliance démocratique
+FRA,6638,Q3550479,Socialist Republican Union,,Union socialiste républicaine
+GUF,5557,Q3077017,Democratic Forces of Guiana,,
+GUF,5556,Q3366765,Guianese Socialist Party,,Parti socialiste guyanais
+GAB,5383,Q2143319,Alliance for Patriotic Reorientation and Construction,APRC,
+GAB,5200,Q1762536,Gabonese Democratic Party,PDG,Parti Démocratique Gabonais
+GAB,7550,Q2945546,Circle of Liberal Reformers,,
+GAB,5294,Q6926679,Movement for National Renewal,,
+GAB,5290,Q3366469,Gabonese Progress Party,,
+GAB,7553,Q3366711,Social Democratic Party,,
+GAB,5592,Q3419915,National Woodcutters' Rally – Rally for Gabon,,
+GAB,5293,Q23023616,Gabonese Democratic and Social Union,,
+GAB,5591,Q3550242,Union of the Gabonese People,,
+GAB,5763,Q22080862,National Union,,
+GAB,7555,Q22074584,Union for the New Republic,,
+GAB,6065,Q5515448,Gabonese Socialist Union,,Union socialiste gabonaise
+GMB,3716,Q2143319,Alliance for Patriotic Reorientation and Construction,APRC,
+GMB,6511,Q1185839,Democratic Congress Alliance,,
+GMB,6509,Q2698062,Democratic Party,,
+GMB,5954,Q28949959,Gambia Democratic Congress,,
+GMB,6215,Q1294641,Gambian People's Party,,
+GMB,6510,Q1492935,Muslim Congress Party,,
+GMB,6066,Q478056,National Alliance for Democracy and Development,,
+GMB,5082,Q1313390,National Convention Party,,
+GMB,3717,Q1786600,National Reconciliation Party,,
+GMB,3718,Q2069620,People's Democratic Organisation for Independence and Socialism,,
+GMB,5084,Q1752906,People's Progressive Party,,
+GMB,3715,Q2495179,United Democratic Party,UDP,United Democratic Party
+GMB,5083,Q1409964,United Party,,
+GEO,2162,Q3103162,New Rights,,ახალი მემარჯვენეები
+GEO,2168,Q1367178,Democratic Union for Revival,,დემოკრატიული აღორძინების კავშირი
+GEO,7091,Q3649358,National Forum,,
+GEO,2172,Q1057495,United National Movement,,ერთიანი ნაციონალური მოძრაობა
+GEO,6954,Q5548046,Georgian Socialist-Federalist Revolutionary Party,,საქართველოს სოციალისტ-ფედერალისტთა სარევოლუციო პარტია
+GEO,2158,Q30646238,Ilia Chavchavadze Society,,
+GEO,2988,Q46516,Georgian Dream,,ქართული ოცნება–დემოკრატიული საქართველო
+GEO,2169,Q7886600,Union of Georgian Traditionalists,,
+GEO,2349,Q3651346,Christian-Democratic Movement,,ქრისტიანულ-დემოკრატიული მოძრაობა
+GEO,2159,Q13612721,Industry Will Save Georgia,,მრეწველობა გადაარჩენს საქართველოს
+GEO,4551,Q12867161,Round Table—Free Georgia,,მრგვალი მაგიდა - თავისუფალი საქართველო
+GEO,2161,Q2331103,National Democratic Party,,ეროვნულ-დემოკრატიული პარტია
+GEO,2154,Q30642509,National Independence Party of Georgia,,
+GEO,7088,Q1327025,United Communist Party of Georgia,,საქართველოს ერთიანი კომუნისტური პარტია
+GEO,4540,Q2446368,Communist Party of Georgian Soviet Socialist Republic,,საქართველოს კომუნისტური პარტია
+GEO,2153,Q1509468,Georgian Labour Party,,საქართველოს ლეიბორისტული პარტია
+GEO,2148,Q639395,Union of Citizens of Georgia,,საქართველოს მოქალაქეთა კავშირი
+GEO,2157,Q3489727,Greens Party,,საქართველოს მწვანეთა პარტია
+GEO,6114,Q22093572,Alliance of Patriots of Georgia,,საქართველოს პატრიოტთა ალიანსი
+GEO,4554,Q1429418,Republican Party of Georgia,,
+GEO,6953,Q2700617,Social Democratic Labour Party of Georgia,,საქართველოს სოციალ-დემოკრატიული პარტია
+GEO,5885,Q183331,Free Democrats,,
+GEO,7089,Q2621209,United Abkhazia,,Аԥсны Акзаара
+DDR,389,Q880561,Association of Free Democrats,B/F/D,Bund Freier Demokraten
+DDR,807,Q446007,Alliance 90,BÜ/90,Bündnis 90
+DDR,1446,Q49754,Christian Democratic Union,Ost/CDU,Christlich-Demokratische Union Deutschlands
+DDR,689,Q49756,Democratic Farmers' Party of Germany,,Demokratische Bauernpartei Deutschlands
+DDR,8607,Q677182,Democratic Awakening,DA,Demokratischer Aufbruch
+DDR,1032,Q558343,Democratic Women's League of Germany,,Demokratischer Frauenbund Deutschlands
+DDR,1158,Q315226,German Forum Party,DFP,Deutsche Forumpartei
+DDR,1645,Q560536,German Social Union,DSU,Deutsche Soziale Union
+DDR,1791,Q316223,East German Green Party,,Grüne Partei
+DDR,792,Q49755,Liberal Democratic Party of Germany,ЛДПГ,Liberal-Demokratische Partei Deutschlands
+DDR,1334,Q49758,National Democratic Party of Germany,НДПГ,National-Demokratische Partei Deutschlands
+DDR,1054,Q152554,Party of Democratic Socialism,ПДС,Partei des Demokratischen Sozialismus / Die Linkspartei.PDS
+DDR,1548,Q563535,Social Democratic Party in the GDR,,Sozialdemokratische Partei in der DDR
+DDR,4658,Q49750,Socialist Unity Party of Germany,СЕПГ,Sozialistische Einheitspartei Deutschlands
+DEU,1976,Q6721203,Alternative for Germany,AfD,Alternative für Deutschland
+DEU,2068,Q812330,Bavarian Peasants' League,,
+DEU,1825,Q302884,Bavarian People's Party,,Bayerische Volkspartei
+DEU,61,Q255857,Bavaria Party,BP,Bayernpartei
+DEU,1816,Q49766,Alliance '90/The Greens,GRÜNE,Bündnis 90/Die Grünen
+DEU,865,Q49766,Alliance '90/The Greens,GRÜNE,Bündnis 90/Die Grünen
+DEU,1375,Q49762,Christian Democratic Union,CDU,Christlich Demokratische Union Deutschlands
+DEU,211,Q708725,CDU/CSU,CDU/CSU,
+DEU,1831,Q315407,Christian-National Peasants' and Farmers' Party,,
+DEU,8723,Q883013,Christian Social Party,,Christlich–soziale Partei
+DEU,2070,Q314832,Christian Social People's Service,,Christlich-Sozialer Volksdienst
+DEU,1731,Q49763,Christian Social Union of Bavaria,CSU,Christlich-Soziale Union in Bayern
+DEU,7372,Q871964,German Farmers' Party,,
+DEU,1826,Q328195,German Democratic Party,НДП,Deutsche Demokratische Partei
+DEU,2108,Q694714,German Progress Party,,Deutsche Fortschrittspartei
+DEU,2111,Q560777,German Free-minded Party,,Deutsche Freisinnige Partei
+DEU,1502,Q674695,German Party,DP,Deutsche Partei
+DEU,2412,Q1203735,German Reform Party,,Deutsche Reformpartei
+DEU,1151,Q495497,Deutsche Reichspartei,,Deutsche Reichspartei
+DEU,2076,Q455038,Free Conservative Party,,Freikonservative Partei
+DEU,2114,Q202590,German People's Party,,Deutsche Volkspartei
+DEU,1827,Q316533,German People's Party,,Deutsche Volkspartei
+DEU,695,Q505829,German People's Union,DVU,Deutsche Volksunion
+DEU,1798,Q157537,Centre Party,ZENTRUM,Deutsche Zentrumspartei
+DEU,1883,Q567550,German-Hanoverian Party,,Deutsch-Hannoversche Partei
+DEU,2125,Q458791,German Conservative Party,,Deutschkonservative Partei
+DEU,1830,Q158227,German National People's Party,DNVP,Deutschnationale Volkspartei
+DEU,2072,Q1206490,German Social Party,,
+DEU,1652,Q462353,The Grays – Gray Panthers,,Die Grauen – Graue Panther
+DEU,10,Q49766,Alliance '90/The Greens,GRÜNE,Bündnis 90/Die Grünen
+DEU,1545,Q49764,The Left,DIE/LINKE,Die Linke
+DEU,6126,Q22748,Die PARTEI,Die/PARTEI,"Partei für Arbeit, Rechtsstaat, Tierschutz, Elitenförderung und basisdemokratische Initiative"
+DEU,720,Q269316,The Republicans,REP,Die Republikaner
+DEU,2101,Q662377,Progressive People's Party,,Fortschrittliche Volkspartei
+DEU,573,Q13124,Free Democratic Party,FDP,Freie Demokratische Partei
+DEU,1152,Q882711,Free People's Party,,
+DEU,1929,Q633731,Free-minded Union,,Freisinnige Vereinigung
+DEU,2113,Q319457,Free-minded People's Party,,Freisinnige Volkspartei
+DEU,8721,Q1206482,German Social Party (German Empire),,Deutschsoziale Partei
+DEU,1031,Q1516101,German Party,DP,Deutsche Partei
+DEU,1010,Q707844,All-German Bloc/League of Expellees and Deprived of Rights,GB/BHE,Gesamtdeutscher Block/Bund der Heimatvertriebenen und Entrechteten
+DEU,845,Q451497,All-German People's Party,GVP,Gesamtdeutsche Volkspartei
+DEU,1135,Q153401,Communist Party of Germany,КПГ,Kommunistische Partei Deutschlands
+DEU,2081,Q1822886,Imperial Liberal Party,,
+DEU,2109,Q942383,Liberal Union,,Liberale Vereinigung
+DEU,1723,Q156019,National Democratic Party of Germany,NPD,Nationaldemokratische Partei Deutschlands
+DEU,2110,Q694299,National Liberal Party,,Nationalliberale Partei
+DEU,1893,Q7320,National Socialist German Workers' Party (Nazi Party),NSDAP,Nationalsozialistische Deutsche Arbeiterpartei
+DEU,4161,Q164866,National Socialist Freedom Movement,,Nationalsozialistische Freiheitsbewegung
+DEU,7345,Q294989,Ecological Democratic Party,ÖDP,Ökologisch-Demokratische Partei
+DEU,86,Q152554,Party of Democratic Socialism,ПДС,Partei des Demokratischen Sozialismus / Die Linkspartei.PDS
+DEU,1287,Q13129,Pirate Party Germany,PIRATEN,Piratenpartei Deutschland
+DEU,2410,Q2102435,Polish Party,,
+DEU,2107,Q896602,Reich Party for Civil Rights and Deflation,,
+DEU,1828,Q541230,Reich Party of the German Middle Class,,Reichspartei des deutschen Mittelstandes
+DEU,383,Q49768,Social Democratic Party of Germany,SPD,Sozialdemokratische Partei Deutschlands
+DEU,50,Q161545,South Schleswig Voter Federation,SSW,
+DEU,749,Q492561,Party Human Environment Animal Protection,Tierschutzpartei,
+DEU,1884,Q310296,Independent Social Democratic Party of Germany,НСДПГ,Unabhängige Sozialdemokratische Partei Deutschlands
+DEU,735,Q895674,Economic Reconstruction Union,,Wirtschaftliche Aufbau-Vereinigung
+GHA,4840,Q343619,Action Congress Party,,
+GHA,4848,Q916141,All People's Republican Party,,
+GHA,3660,Q1129392,Convention People's Party,,Apam Nkorɔfo Kuw ([[Akan language|Akan]])
+GHA,4733,Q1967433,National Liberation Movement,,
+GHA,4052,Q1544243,Great Consolidated Popular Party,,
+GHA,4834,Q690836,National Alliance of Liberals,,
+GHA,4842,Q1967014,National Convention Party,NCP,
+GHA,2311,Q200875,National Democratic Congress,NDC,
+GHA,3659,Q1405274,National Reform Party,,
+GHA,2312,Q1148441,New Patriotic Party,,"New Patriotic Party, NPP"
+GHA,4732,Q1253664,Northern People's Party,,
+GHA,4843,Q2069610,People's Convention Party,,
+GHA,2310,Q2069628,People's National Convention,,
+GHA,4837,Q2069633,People's National Party,,
+GHA,4838,Q2104298,Popular Front Party,,
+GHA,4833,Q2112227,Progress Party,,
+GHA,4841,Q1688600,Social Democratic Front,,
+GHA,6593,Q2495200,United Gold Coast Convention,,United Gold Coast Convention
+GHA,4839,Q1578600,United National Convention,,
+GHA,4835,Q2495249,United Nationalist Party,,
+GIB,6946,Q4809542,Association for the Advancement of Civil Rights,,
+GIB,6952,Q5153824,Commonwealth Party,,
+GIB,6948,Q1185871,Democratic Party of British Gibraltar,,
+GIB,3853,Q1522965,Gibraltar Labour Party,GLP,
+GIB,3848,Q152744,Liberal Party of Gibraltar,,
+GIB,3855,Q136754,Gibraltar Social Democrats,,
+GIB,3851,Q53025,Gibraltar Socialist Labour Party,,
+GIB,6931,Q22088817,GSLP–Liberal Alliance,,
+GIB,6950,Q15982329,Integration with Britain Party,,
+GIB,6951,Q16978735,Isola Group,,
+GIB,3849,Q7248733,Progressive Democratic Party,,
+GRC,4442,Q800096,Agricultural and Labour Party,,Δημοκρατική Ένωσις-Αγροτικόν Εργατικόν Κόμμα
+GRC,4443,Q16975710,Farmers' Party,,
+GRC,7111,Q724682,All People Front,,Παλλαϊκό Μέτωπο
+GRC,1651,Q529666,Independent Greeks,ANEL,Ανεξάρτητοι Έλληνες
+GRC,95,Q3544318,Front of the Greek Anticapitalist Left,,
+GRC,274,Q169228,Christian Democracy,,
+GRC,7113,Q5255831,Democratic Socialist Party of Greece,,Δημοκρατικό Σοσιαλιστικό Κόμμα Ελλάδος
+GRC,471,Q7303029,Recreate Greece,,
+GRC,648,Q3555896,Democratic Renewal,,
+GRC,1160,Q1128823,Democratic Left,DIMAR,Δημοκρατική Αριστερά (ΔΗΜΑΡ)
+GRC,4452,Q16945570,Democratic Union,,
+GRC,1284,Q1226117,Democratic Alliance,,Δημοκρατική Συμμαχία
+GRC,1682,Q1226100,Democratic Social Movement,DIKKI,Δημοκρατικό Κοινωνικό Κίνημα
+GRC,1130,Q5305890,Drasi,,
+GRC,4156,Q3563354,Greek Rally,,
+GRC,7347,Q50736163,Greek Solution,,
+GRC,4157,Q201478,United Democratic Left,ΕΔΑ,Ενιαία Δημοκρατική Αριστερά
+GRC,82,Q3565854,Union of the Democratic Centre,,Ένωση Δημοκρατικού Κέντρου
+GRC,2510,Q3567209,Union of Centrists,ΕΚ,
+GRC,4158,Q1343608,Centre Union,,Ἔνωσις Κέντρου
+GRC,6429,Q3565847,Centre Union – New Forces,,Ένωσις Κέντρου-Νέες Δυνάμεις
+GRC,943,Q3563369,National Alignment,,
+GRC,4573,Q6974991,National Political Union,,
+GRC,231,Q3555911,National Political Union,,Εθνική Πολιτική Ένωσις
+GRC,4439,Q3558610,National Progressive Center Union,,Εθνική Προοδευτική Ένωση Κέντρου
+GRC,4441,Q1371314,National Radical Union,,ΕΡΕ
+GRC,4453,Q16919460,National Democratic Party,,Εθνικόν Δημοκρατικόν Κόμμα
+GRC,4312,Q15980817,National Party of Greece,,Εθνικόν Κόμμα Ελλάδος
+GRC,4440,Q16919460,National Democratic Party,,Εθνικόν Δημοκρατικόν Κόμμα
+GRC,2414,Q15980818,National Democratic Union (Greece),,Εθνική Δημοκρατική Ένωσις
+GRC,8287,Q6540621,Liberal Democratic Center,,
+GRC,8645,Q3563454,Alternative Ecologists,,Οικολόγοι Εναλλακτικοί
+GRC,7909,Q46505372,Movement for Change,KINAL,Κίνημα Αλλαγής
+GRC,3212,Q18707655,Movement of Democratic Socialists,,Κίνημα Δημοκρατών Σοσιαλιστών
+GRC,1030,Q169223,Party of Democratic Socialism,,
+GRC,2508,Q7141083,Party of Greek Hunters,,Κόμμα Ελλήνων Κυνηγών
+GRC,6785,Q3366549,Nationalist Party,,
+GRC,3280,Q937927,Liberal Party,,Κόμμα Φιλελευθέρων
+GRC,4155,Q1194748,Georgios Papandreou Party,,
+GRC,1298,Q3561226,Party of New Liberals,,Κόμμα Νεοφιλελευθέρων
+GRC,619,Q169225,Progressive Party,,
+GRC,4438,Q3544903,Freethinkers' Party,,Κόμμα των Ελευθεροφρόνων
+GRC,207,Q6540704,Liberal Party,,
+GRC,48,Q192406,Communist Party of Greece,,Κομμουνιστικό Κόμμα Ελλάδας
+GRC,334,Q3565932,Communist Party of Greece (Interior),KKE/Interior,Κομμουνιστικό Κόμμα Ελλάδας Εσωτερικού
+GRC,4512,Q20855700,Popular Unity,,Λαϊκή Ενότητα
+GRC,4580,Q724679,Popular Social Party,,
+GRC,4444,Q782419,People's Party,,
+GRC,965,Q226085,Popular Orthodox Rally,,Λαϊκός Ορθόδοξος Συναγερμός
+GRC,1660,Q82256,Golden Dawn,ΧΑ,
+GRC,7115,Q6516883,Left Liberals,,Αριστερoί Φιλελεύθεροι
+GRC,4572,Q16930532,National Reform Party,,
+GRC,7348,Q61046702,MeRA25,,Μέτωπο Ευρωπαϊκής Ρεαλιστικής Ανυπακοής
+GRC,4578,Q868748,National Unionist Party,,
+GRC,7424,Q14567930,National Committee,,
+GRC,6631,Q6975214,National Reconstruction Front,,
+GRC,6784,Q868748,National Unionist Party,,
+GRC,794,Q223153,New Democracy,ND/ΝΔ,Νέα Δημοκρατία
+GRC,4579,Q1284538,New Party,,
+GRC,2509,Q7747053,The Liberals,,Οι Φιλελεύθεροι
+GRC,378,Q1275573,Ecologist Greens,,Οικολόγοι Πράσινοι
+GRC,1468,Q203934,Panhellenic Socialist Movement,PASOK/ΠΑΣΟΚ,Πανελλήνιο Σοσιαλιστικό Κίνημα
+GRC,2511,Q3562088,Panhellenic Macedonian Front,,
+GRC,7116,Q7225144,Politically Independent Alignment,,Πολιτική Ανεξάρτητος Παράταξις
+GRC,312,Q2064301,Political Spring,,
+GRC,4577,Q111514957,Progressive Union,,
+GRC,7114,Q14475918,Socialist Party of Greece,,
+GRC,301,Q222897,SYRIZA,,Συνασπισμός Ριζοσπαστικής Αριστεράς – Προοδευτική Συμμαχία Sinaspismós
+GRC,516,Q219573,Synaspismós,,Συνασπισμός της Αριστεράς των Κινημάτων και της Οικολογίας
+GRC,4581,Q16964210,Conservative Democratic Party,,
+GRC,3211,Q22080093,Teleia,,Τελεία
+GRC,3118,Q15920068,The River,,Το Ποτάμι
+GRC,8846,Q7889008,United Opposition,,
+GRL,6121,Q16900269,Centre Party (Greenland),,
+GRL,5533,Q753751,Atassut,A,
+GRL,5534,Q1090630,Democrats,D,Demokraatit
+GRL,5531,Q1128374,Inuit Ataqatigiit,IA,Inuit Ataqatigiit
+GRL,6956,Q734437,Association of Candidates,,Kattusseqatigiit
+GRL,8243,Q50802925,Nunatta Qitornai,,Nunatta Qitornai
+GRL,5532,Q7428697,Inuit Party,,Partii Inuit
+GRL,5536,Q16856492,Naleraq,,
+GRL,5535,Q571175,Siumut,,Siumut
+GRL,6957,Q6467445,Labour Party,,
+GRD,3861,Q5607370,Grenada National Party,,
+GRD,4431,Q5607378,Grenada United Labour Party,,
+GRD,4240,Q1254278,National Democratic Congress,NDC,
+GRD,8384,Q1267080,New Jewel Movement,New/JEWEL/Movement,
+GRD,3859,Q1288287,New National Party,,New National Party
+GRD,3857,Q7753206,The National Party,,
+GTM,8061,Q54263417,Bienestar Nacional,,
+GTM,4426,Q5761555,Social Action Centre,,
+GTM,4424,Q5780134,"Commitment, Renewal and Order",,"Compromiso, Renovación y Orden"
+GTM,1322,Q2297948,Guatemalan Christian Democracy,,Democracia Cristiana Guatemalteca
+GTM,2487,Q4825864,Authentic Integral Development,,
+GTM,1413,Q4613840,Encuentro por Guatemala,,Encuentro por Guatemala
+GTM,5955,Q5869416,National Convergence Front,,
+GTM,941,Q116740520,Institutional Republican Party,,Partido Republicano Institucional
+GTM,7243,Q7887802,United Front of Political Parties and Civic Associations,,
+GTM,5957,Q20652377,Fuerza,,
+GTM,538,Q1062788,Grow Party,,Gran Alianza Nacional
+GTM,4337,Q5944368,Renewed Democratic Liberty,,Libertad Democrática Renovada
+GTM,4334,Q2185969,National Liberation Movement,,Movimiento de Liberación Nacional
+GTM,7911,Q56274977,Semilla Movement,,
+GTM,4782,Q7318726,Revolutionary Action Party,,Partido Acción Revolucionaria
+GTM,8316,Q5163058,Conservative Party,,Partido Conservador
+GTM,1035,Q2073191,National Advancement Party,,Partido de Avanzada Nacional
+GTM,4734,Q2063777,Guatemalan Party of Labour,,Partido Guatemalteco del Trabajo
+GTM,8063,Q56274973,Partido Humanista de Guatemala,,Partido Humanista de Guatemala
+GTM,4437,Q6041139,Institutional Democratic Party,,Partido Institucional Democrático
+GTM,5242,Q25204703,Liberal Party,,Partido Liberal
+GTM,524,Q1803640,Patriotic Party,,Partido Patriota
+GTM,4736,Q6972246,National Democratic Reconciliation Party,,
+GTM,5967,Q116740520,Institutional Republican Party,,Partido Republicano Institucional
+GTM,4425,Q7318829,Revolutionary Party,,Partido Revolucionario
+GTM,5241,Q7551632,Socialist Party,,
+GTM,71,Q2395412,Unionist Party,,Partido Unionista
+GTM,5966,Q6064406,Todos,,
+GTM,1668,Q1237557,National Unity of Hope,UNE,Unidad Nacional de la Esperanza
+GTM,5971,Q430960,Guatemalan National Revolutionary Unity,URNG/MAIZ,Unidad Revolucionaria Nacional Guatemalteca
+GTM,706,Q6979766,National Change Union,,Unión del Cambio Nacional
+GTM,8060,Q54263202,Valor (political party),,Valor
+GTM,7910,Q54263394,Vamos,,
+GTM,6856,Q6163926,VIVA,,Visión con Valores
+GIN,6446,Q7551545,Socialist Democracy of Guinea,,Démocratie Socialiste de Guinée
+GIN,4275,Q3550145,Union of Republican Forces,UFR,Union des Forces Républicaines
+GIN,5780,Q1583061,Unity and Progress Party,PUP,Parti de l'Unité et du Progrès
+GIN,4737,Q1186265,Democratic Party of Guinea – African Democratic Rally,PDG/RDA,Parti Démocratique de Guinée-Rassemblement Démocratique Africain
+GIN,4063,Q2663294,Rally of the Guinean People,,
+GIN,7334,Q1332068,French Section of the Workers' International,СФИО,Section française de l'Internationale ouvrière
+GIN,4274,Q577455,Union of Democratic Forces of Guinea,,Union des forces démocratiques de Guinée
+GIN,4276,Q7886460,Union for Progress and Renewal,UPR,Union pour le Progrès et le Renouveau
+GNB,7559,Q65086399,Assembly of the People United,,
+GNB,4233,Q1455523,Struggle Front for the National Independence of Guinea,,
+GNB,8046,Q16740046,Democratic Front,,
+GNB,8048,Q17043850,Democratic Social Front,,
+GNB,8049,Q16739990,Guinean League for Ecological Protection,,
+GNB,7901,Q62258541,Madem G-15,,Movimento Para Alternância Democrâtica
+GNB,8051,Q16978150,Unity Movement for Democracy,,
+GNB,4237,Q776352,African Party for the Independence of Guinea and Cape Verde,PAIGC,Partido Africano para a Independência da Guiné e Cabo Verde
+GNB,4234,Q17070796,Democratic Convergence Party,,
+GNB,5159,Q16957358,New Democracy Party,,
+GNB,4236,Q461351,Party for Social Renewal,,Partido da Renovaçao Social
+GNB,8047,Q16955766,Democratic Party of Progress,,
+GNB,8050,Q17037979,Party for Renewal and Development,,
+GNB,5158,Q16968513,Republican Party for Independence and Development,,
+GNB,8811,Q17103380,Social Democratic Party,,
+GNB,4238,Q7889155,United Social Democratic Party,,Partido Unido Social Democrático
+GNB,4235,Q7315625,Resistance of Guinea-Bissau-Bafatá Movement,,
+GNB,5915,Q7886422,Union for Change,UM,
+GUY,3882,Q3625443,Alliance for Change,,
+GUY,7119,Q16824207,A Partnership for National Unity,APNU,
+GUY,8711,Q5622721,Guyana Action Party,GAP,
+GUY,4243,Q16895537,National Labour Front,,
+GUY,4247,Q647210,People's National Congress,,
+GUY,4246,Q1972521,People's Progressive Party,PPP/C,The People's Progressive Party of Guyana
+GUY,4242,Q7771570,The United Force,,
+GUY,6067,Q17111428,Working People's Alliance,,
+HTI,5268,Q1395689,Fanmi Lavalas,,Famille Lavalas
+HTI,5270,Q3366461,Fusion of Haitian Social Democrats,,Fuzyon Sosyodemokrat Ayiti
+HTI,5828,Q3088455,Lespwa,,Fwon Lespwa
+HTI,7253,Q21207600,Haitian Tèt Kale Party,PHTK,
+HTI,5271,Q22032417,Patriotic Unity,,
+HTI,6393,Q5639708,Haiti in Action,AAA,Haïti en Action
+HTI,5602,Q3356033,Struggling People's Organization,,Òganizasyon Pèp Kap Lité
+HTI,5601,Q3419888,Rally of Progressive National Democrats,,Rassemblement des Démocrates Nationaux Progressistes
+HTI,6069,Q3456317,Peasant Response,,Repons Peyizan
+HTI,5829,Q5109956,Christian National Union for the Reconstruction of Haiti,,Union Nationale Chrétienne pour la Reconstruction d'Haiti
+HND,8813,Q18335842,Honduran Patriotic Alliance,,Alianza Patriótica Hondureña
+HND,5161,Q970952,Liberty and Refoundation,Libre,Libertad y Refundación
+HND,5160,Q7140524,Anti-Corruption Party,,Partido Anticorrupción de Honduras
+HND,1460,Q2689839,Christian Democratic Party of Honduras,,Partido Demócrata Cristiano de Honduras
+HND,1703,Q6036212,Innovation and Unity Party,,Partido Innovación y Unidad Social Demócrata
+HND,593,Q538272,Liberal Party of Honduras,,Partido Liberal de Honduras
+HND,1416,Q1579466,National Party of Honduras,PNH,Partido Nacional de Honduras
+HND,1051,Q5255838,Democratic Unification Party,,Partido Unificación Democrática
+HND,6714,Q5060328,Central American Unionist Party,,
+HKG,8007,Q2914027,Business and Professionals Alliance for Hong Kong,BPA,
+HKG,6961,Q5122722,Citizens Party,,
+HKG,4518,Q23055,Civic Party,,
+HKG,8008,Q16923430,Civic Passion,,
+HKG,5620,Q21916,Democratic Alliance for the Betterment and Progress of Hong Kong,DAB,
+HKG,4519,Q21892,Democratic Party,,
+HKG,7081,Q837695,Association for Democracy and People's Livelihood,ADPL,
+HKG,8002,Q5894453,Hong Kong Confederation of Trade Unions,,
+HKG,5621,Q23062,Hong Kong Federation of Trade Unions,FTU,
+HKG,8006,Q5894952,Hong Kong Progressive Alliance,,
+HKG,8010,Q23888370,Hong Kong Resurgence Order,,
+HKG,7000,Q6435071,Kowloon West New Dynamic,,
+HKG,4521,Q23057,Labour Party,,
+HKG,4522,Q1026514,League of Social Democrats,LSD,
+HKG,8005,Q6540622,Liberal Democratic Federation of Hong Kong,,
+HKG,8001,Q23060,Liberal Party,,
+HKG,8004,Q10904250,Meeting Point,,
+HKG,7080,Q6988161,Neighbourhood and Worker's Service Centre,,
+HKG,6960,Q1026702,Neo Democrats,,
+HKG,6962,Q23059,New People's Party,,
+HKG,7001,Q2275784,New Territories Association of Societies,,
+HKG,4520,Q1026597,People Power,,
+HKG,8009,Q11089837,Proletariat Political Institute,,
+HKG,6999,Q10898980,The Frontier,,
+HKG,8003,Q4253937,United Democrats of Hong Kong,,
+HUN,1132,Q519000,Agrarian Alliance,,
+HUN,1779,Q856197,Centre Party,,Centrum Párt
+HUN,8118,Q16965204,Christian National Economic Party,,
+HUN,469,Q847504,Democratic Coalition,,Demokratikus Koalíció
+HUN,5126,Q988305,Unity Party,EP,Egységes Párt
+HUN,2458,Q3054830,Together 2014,,Együtt
+HUN,6366,Q50583624,Fidesz–KDNP,,Fidesz–KDNP pártszövetség
+HUN,1691,Q387006,Fidesz,,Fidesz – Magyar Polgári Szövetség
+HUN,5756,Q1006287,"Independent Smallholders, Agrarian Workers and Civic Party",,"Független Kisgazda, Földmunkás és Polgári Párt"
+HUN,1294,Q1006287,"Independent Smallholders, Agrarian Workers and Civic Party",,"Független Kisgazda, Földmunkás és Polgári Párt"
+HUN,6720,Q15639359,Independent Hungarian Democratic Party,,Független Magyar Demokrata Párt
+HUN,6814,Q1006324,Party of Independence and '48,,Függetlenségi és 48-as Párt
+HUN,42,Q633442,Jobbik,Jobbik,Jobbik Magyarországért Mozgalom
+HUN,1412,Q277879,Christian Democratic People's Party,KDNP,Kereszténydemokrata Néppárt
+HUN,6718,Q1107497,Christian Economic and Social Party,KGSZP,Keresztény Gazdasági és Szociális Párt
+HUN,6029,Q1107502,Christian National Union Party,KNEP,Keresztény Nemzeti Egyesülés Pártja
+HUN,1650,Q54801,Politics Can Be Different,LMP,LMP – Magyarország Zöld Pártja
+HUN,1697,Q766275,Hungarian Democratic Forum,,Magyar Demokrata Fórum
+HUN,5753,Q1073752,Hungarian Working People's Party,,Magyar Dolgozók Pártja
+HUN,6721,Q1161937,Hungarian Independence Party,,
+HUN,1597,Q1051742,Hungarian Justice and Life Party,,
+HUN,6129,Q832920,Hungarian Two-tailed Dog Party,MKKP,Magyar Kétfarkú Kutya Párt
+HUN,859,Q584730,Hungarian Workers' Party,,Magyar Munkáspárt
+HUN,5754,Q925418,Hungarian Communist Party,,
+HUN,8119,Q1162125,Hungarian National Independence Party,,Magyar Nemzeti Függetlenségi Párt
+HUN,1726,Q897658,Hungarian Social Democratic Party,MSZDP,Magyarországi Szociáldemokrata Párt
+HUN,5755,Q897658,Hungarian Social Democratic Party,MSZDP,Magyarországi Szociáldemokrata Párt
+HUN,299,Q16412,Hungarian Socialist Workers' Party,,Magyar Szocialista Munkáspárt
+HUN,1408,Q753223,Hungarian Socialist Party,MSZP,Magyar Szocialista Párt
+HUN,8264,Q716092,MIÉP–Jobbik Third Way Alliance of Parties,,MIÉP – Jobbik a Harmadik Út
+HUN,7349,Q55443054,Our Homeland Movement,MHM,
+HUN,8249,Q28563736,Momentum Movement,Momentum,Momentum Mozgalom
+HUN,6819,Q1216660,National Party of Work,,Nemzeti Munkapárt
+HUN,6719,Q1216666,National Peasant Party,,Nemzeti Parasztpárt
+HUN,5127,Q160159,Arrow Cross Party,NYKP,Nyilaskeresztes Párt – Hungarista Mozgalom
+HUN,6818,Q1226105,National Constitution Party,,Országos Alkotmánypárt
+HUN,8265,Q15728091,Unity,,Összefogás
+HUN,3115,Q15177537,Dialogue for Hungary,,Párbeszéd Magyarországért
+HUN,7256,Q1238308,Civic Democratic Party,PDP,Polgári Demokrata Párt
+HUN,910,Q200599,Alliance of Free Democrats,,Szabad Demokraták Szövetsége – a Magyar Liberális Párt
+HUN,6813,Q722796,Liberal Party,,Szabadelvű Párt
+HUN,184,Q1461637,Entrepreneurs' Party,,
+ISL,1249,Q2165306,People's Alliance,,Alþýðubandalagið
+ISL,1325,Q1753703,Social Democratic Party,,Alþýðuflokkurinn
+ISL,1953,Q16975715,Farmers' Party,,
+ISL,1951,Q16975721,Farmers' Party,,
+ISL,854,Q806257,Alliance of Social Democrats,,
+ISL,2517,Q5019160,Bright Future,,Björt framtíð
+ISL,1433,Q1021378,Citizens' Party,,Borgaraflokkurinn
+ISL,224,Q747640,Citizens' Movement,,Borgarahreyfingin
+ISL,2518,Q4415446,Dawn,,Dögun
+ISL,5852,Q27273216,People's Party,,Flokkur Fólksins
+ISL,2519,Q4415446,Dawn,,Dögun
+ISL,964,Q1046777,Progressive Party,,Framsóknarflokkurinn
+ISL,1224,Q1421878,Liberal Party,,Frjálslyndi flokkurinn
+ISL,1890,Q6540707,Liberal Party,,Frjálslyndi flokkurinn
+ISL,2516,Q7333442,Right-Green Movement,,Hægri Grænir flokkur fólksins
+ISL,1958,Q3482235,Home Rule Party,,
+ISL,1891,Q3354593,Conservative Party,,Íhaldsflokkurinn
+ISL,125,Q572015,Icelandic Movement – Living Country,,Íslandshreyfingin – lifandi land
+ISL,1881,Q1576363,Communist Party of Iceland,,
+ISL,2514,Q12543188,Iceland Democratic Party,,
+ISL,77,Q7314622,Republican Party,,Lýðveldisflokkurinn
+ISL,7565,Q41280154,Centre Party,,Miðflokkurinn
+ISL,1956,Q16981267,Independent Farmers,,
+ISL,2048,Q198403,Pirate Party Iceland,,Píratar
+ISL,2515,Q12813937,Rainbow (Iceland),,Regnboginn
+ISL,8173,Q7885947,Union Party,,
+ISL,1396,Q1141127,Social Democratic Alliance,,Samfylkingin
+ISL,1517,Q3319471,Union of Liberals and Leftists,,
+ISL,525,Q1451591,Women's List,,
+ISL,363,Q218303,Independence Party,,Sjálfstæðisflokkurinn
+ISL,1954,Q6016153,Independence Party,,Sjálfstæðisflokkurinn
+ISL,1957,Q6016153,Independence Party,,Sjálfstæðisflokkurinn
+ISL,1952,Q6016153,Independence Party,,Sjálfstæðisflokkurinn
+ISL,1208,Q1974972,People's Unity Party – Socialist Party,,
+ISL,5454,Q23789296,Liberal Reform Party,,Viðreisn
+ISL,457,Q1130754,Left-Green Movement,VG,Vinstrihreyfingin – grænt framboð
+ISL,494,Q1166996,National Awakening,,Þjóðvaki – Hreyfing Fólksins
+ISL,673,Q674581,National Preservation Party,,Þjóðvarnarflokkurinn
+IND,5180,Q129844,Aam Aadmi Party,AAP,
+IND,1571,Q651141,All India Anna Dravida Munnetra Kazhagam,AIADMK,
+IND,7257,Q223898,All India Muslim League,,آل اِنڈِیا مُسْلِم لِیگ
+IND,2494,Q912899,All India Trinamool Congress,AITC,
+IND,5177,Q2740234,Asom Gana Parishad,AGP,
+IND,937,Q803681,Bahujan Samaj Party,BSP,
+IND,6321,Q1455015,Left Front,,
+IND,4787,Q3245961,Bharatiya Jana Sangh,,
+IND,422,Q10230,Bharatiya Janata Party,BJP,भारतीय जनता पार्टी
+IND,408,Q837159,Communist Party of India,CPI,भारतीय कम्युनिस्ट पार्टी
+IND,5182,Q3380843,Bharatiya Kranti Dal,,
+IND,4100,Q3595130,Bharatiya Lok Dal,,
+IND,2495,Q859993,Biju Janata Dal,BJD,ବିଜୁ ଜନତା ଦଳ
+IND,893,Q234277,Communist Party of India (Marxist),CPI/M/or/CPIM/or/CPM,भारत की कम्युनिस्ट पार्टी (मार्क्सवादी)
+IND,6217,Q5160848,Congress for Democracy,,
+IND,7258,Q16979731,Congress Nationalist Party,,
+IND,17,Q1255973,Dravida Munnetra Kazhagam,DMK,
+IND,4104,Q13111739,Indian Congress (Socialist),,
+IND,7261,Q6020892,Indian Liberal Party,,
+IND,1297,Q10225,Indian National Congress,INC,भारतीय राष्ट्रीय कांग्रेस
+IND,6639,Q3523002,Indian National Congress (Organisation),INC/O,
+IND,8733,Q6021036,Indian National Congress (R),INC/R,
+IND,4105,Q6021043,Indian National Congress (U),INC/U,
+IND,1455,Q3196786,Indian Union Muslim League,I/U/M/L,
+IND,8937,Q1626979,Jammu & Kashmir National Conference,JKNC,
+IND,1207,Q1682547,Janata Dal,JD,
+IND,4112,Q6150829,Janata Dal (Ajit),,
+IND,2496,Q1601619,Janata Dal (Secular),JD/S,
+IND,2498,Q904827,Janata Dal (United),JD/U,
+IND,4788,Q2352638,Janata Party,JP,
+IND,5178,Q6150842,Janata Party (Secular),JP/S,
+IND,2490,Q1561861,Nationalist Congress Party,NCP,
+IND,8935,Q1887353,Pattali Makkal Katchi,PMK,
+IND,5174,Q3633824,Praja Socialist Party,,
+IND,2497,Q3176919,Rashtriya Janata Dal,RJD,
+IND,5175,Q3279403,Republican Party of India,,
+IND,8493,Q10660839,Samajwadi Janata Party,SJP/R,
+IND,2491,Q1546941,Samajwadi Party,SP,
+IND,4102,Q3781719,Samata Party,SAP,
+IND,5181,Q7413188,Samyukta Socialist Party,,
+IND,2499,Q148034,Shiromani Akali Dal,,
+IND,4103,Q7498934,Shiromani Akali Dal (Amritsar),,
+IND,2394,Q59177,Shiv Sena,,
+IND,7260,Q2605500,Swaraj Party,,
+IND,5176,Q2002819,Swatantra Party,SWA,
+IND,2492,Q2279320,Telugu Desam Party,TDP,
+IND,5179,Q8046035,YSR Congress Party,YSRCP/or/YCP,
+IDN,4499,Q686441,Nahdlatul Ulama,,
+IDN,2557,Q2434365,National Mandate Party,PAN,Partai Amanat Nasional
+IDN,4212,Q4261778,Reform Star Party,PBR,
+IDN,4211,Q7250923,Prosperous Peace Party,PDS,Partai Damai Sejahtera
+IDN,4498,Q2084109,Indonesian Democratic Party,PDI,Partai Demokrasi Indonesia
+IDN,2560,Q1186306,Indonesian Democratic Party – Struggle,PDIP,Partai Demokrasi Indonesia Perjuangan
+IDN,2561,Q1186227,Democratic Party,Dem,Partai Demokrat
+IDN,4495,Q4261459,Great Indonesia Movement Party,Partai/Gerindra,
+IDN,2304,Q1536552,Golongan Karya Party,Partai/Golkar,Partai Golongan Karya
+IDN,4497,Q4262041,People's Conscience Party,Partai/Hanura,
+IDN,4209,Q5158454,Concern for the Nation Functional Party,PKPB,
+IDN,4476,Q13405290,Indonesian Justice and Unity Party,PKPI,
+IDN,2556,Q1511101,Prosperous Justice Party,PKS,Partai Keadilan Sejahtera
+IDN,2559,Q1257317,National Awakening Party,PKB,Partai Kebangkitan Bangsa
+IDN,4503,Q157744,Communist Party of Indonesia,PKI,Partai Komunis Indonesia
+IDN,5300,Q2579297,Masyumi Party,Masyumi,Partai Majelis Syuro Muslimin Indonesia
+IDN,4501,Q60679977,Parmusi,Parmusi,Partai Muslimin Indonesia
+IDN,4496,Q4207219,Nasdem Party,,
+IDN,4500,Q1965221,Indonesian National Party,,Partai Nasional Indonesia
+IDN,2558,Q2669302,United Development Party,PPP,Partai Persatuan Pembangunan
+IDN,8504,Q204699,Socialist Party of Indonesia,PSI,Partai Sosialis Indonesia
+IRN,6322,Q20987770,Council for coordinating the Reforms Front,,شورای هماهنگی جبهه اصلاحات
+IRN,4739,Q1968072,National Front,,جبهه‌ ملی
+IRN,8497,Q5321356,E'tedalion Party,,
+IRN,6053,Q2610417,Alliance of Builders of Islamic Iran,,ائتلاف آبادگران ایران اسلامی
+IRN,7263,Q5664897,Democrat Party of Iran,,
+IRN,7265,Q5960938,National Will Party,,
+IRN,8495,Q28169540,Reformers' Party,,
+IRN,7816,Q6888510,Moderation and Development Party,,
+IRN,7264,Q28169816,National Union Party,,حزب اتحاد ملی
+IRN,7814,Q2425963,National Trust Party,,حزب اعتماد ملی ایران
+IRN,6873,Q1130560,Muslim People's Republic Party,,
+IRN,6871,Q28169527,Nationalists’ Party,,
+IRN,7818,Q2843214,Islamic Coalition Party,,
+IRN,8494,Q7318529,Revival Party,,
+IRN,7266,Q28169777,Justice Party,,
+IRN,6650,Q10292318,New Iran Party,,
+IRN,5802,Q640379,Islamic Republican Party,,
+IRN,5166,Q7887801,United Front of Conservatives,,جبههٔ متحد اصولگرایان
+IRN,5359,Q1817687,Combatant Clergy Association,,جامعۀ روحانیت مبارز
+IRN,7819,Q10860765,Society of Devotees of the Islamic Revolution,,
+IRN,7821,Q5505887,Front of Islamic Revolution Stability,,
+IRN,6875,Q1509407,Islamic Iran Participation Front,,جبهه مشارکت ایران اسلامی
+IRN,5360,Q655126,Executives of Construction Party,,حزب کارگزاران سازندگی ایران‎
+IRN,4738,Q25209595,People's Party,,
+IRN,6872,Q1672383,Freedom Movement of Iran,,
+IRN,7568,Q7165813,People's Voice,,ائتلاف صدای ملت
+IRN,7567,Q22960717,Pervasive Coalition of Reformists,,ائتلاف فراگير اصلاح‌طلبان
+IRN,7569,Q23006331,Principlists Grand Coalition,,ائتلاف بزرگ اصول‌گرایان
+IRN,5803,Q1817611,Rastakhiz Party,,
+IRN,6874,Q2068291,Association of Combatant Clerics,,مجمع روحانیون مبارز
+IRN,7820,Q20900631,Society of Pathseekers of the Islamic Revolution,,جمعيت رهپويان انقلاب اسلامی
+IRN,4740,Q1339294,Tudeh Party of Iran,,
+IRN,7815,Q20110042,Union of Islamic Iran People Party,,
+IRQ,7845,Q4702437,al-Hadba,,
+IRQ,8821,Q1572765,Iraqi National Movement,,al-Haraka al-Wataniya al-Iraqiyya
+IRQ,7832,Q1672366,Iraqi Communist Party,ICP,الحزب الشيوعي العراقي
+IRQ,5897,Q1377438,National Iraqi Alliance,,الائتلاف الوطني العراقي
+IRQ,6880,Q60763877,Constitutional Union Party,,حزب الاتحاد الدستوري
+IRQ,7471,Q3088531,Iraqi National Dialogue Front,,الجبهة العراقية للحوار الوطني
+IRQ,6879,Q15980859,United Popular Front (Iraq),,الجبهة الشعبية المتحدة
+IRQ,7121,Q940293,Iraqi National Congress,,المؤتمر الوطني العراقي
+IRQ,7828,Q18161820,Al-Sadiqoun Bloc,,كتلة الصادقون
+IRQ,5927,Q3291634,Sadrist Movement,,التيار الصدري
+IRQ,7123,Q17003538,Al-Wataniya,,ائتلاف الوطنية
+IRQ,5614,Q2627514,Iraqi National Accord,,الوفاق الوطني العراقي
+IRQ,3661,Q852347,Movement for Change,,بزووتنه‌وەی گۆڕان
+IRQ,7584,Q53847112,Coalition for Democracy and Justice,CDJ,ھاوپەیمانی بۆ دیموکراسی و دادپەروەری
+IRQ,7589,Q47005760,Eradaa Movement,,حركة إرادة
+IRQ,5361,Q1878844,Arab Socialist Baath Party – Iraq Region,,حزب البعث العربي الاشتراكي في العراق
+IRQ,5615,Q1048242,Islamic Dawa Party,,حزب الدعوة الإسلامية
+IRQ,7270,Q7141097,Party of National Brotherhood,,حزب الاخاء الوطني
+IRQ,5618,Q2618800,Iraqi Islamic Party,,Hizb al-Islami al-Iraqi
+IRQ,7826,Q18210815,People's Party,,حزب الشعب للإصلاح
+IRQ,7595,Q1424473,Iraqi Turkmen Front,ITF,
+IRQ,5924,Q6067949,Iraqi Accord Front,,
+IRQ,8820,Q3233379,The Iraqis,,العراقيون
+IRQ,7594,Q1971776,State of Law Coalition,,إئتلاف دولة القانون
+IRQ,7122,Q17068727,Muttahidoon,,ائتلاف متحدون للاصلاح
+IRQ,5752,Q16825331,Arab Socialist Union,,الاتحاد الاشتراكي العربي العراقي
+IRQ,8701,Q1297375,People's Union,,اتحاد الشعب
+IRQ,7585,Q47487535,Fatah Alliance,,ائتلاف الفتح
+IRQ,7597,Q47487622,Victory Alliance,,
+IRQ,3662,Q1644886,Ali Bapir,,عه‌لی باپیر
+IRQ,5917,Q1419636,Democratic Patriotic Alliance of Kurdistan,,
+IRQ,5919,Q2838092,Kurdistan List,,
+IRQ,7580,Q3822970,Chaldean Syriac Assyrian Popular Council,,"ܡܘܬܒܐ ܥܡܡܝܐ ܟܠܕܝܐ ܣܘܪܝܝܐ ܐܬܘܪܝܐ
+"
+IRQ,7827,Q2994636,Badr Organization,,منظمة بدر
+IRQ,7690,Q12186321,National Movement for Development and Reform,,الحركة الوطنية للاصلاح والتنمية
+IRQ,7592,Q55075157,New Generation Movement,,جوڵانه‌وه‌ی نه‌وه‌ی نوێ
+IRQ,5617,Q781221,Kurdistan Democratic Party,PDK,پارتی دیموکراتی کوردستان
+IRQ,7696,Q48815784,Alliance of Revolutionaries for Reform,,تحالف سائرون للإصلاح
+IRQ,6878,Q60763879,Socialist Nation Party,,حزب الامة الاشتراكي
+IRQ,7669,Q48818196,Civilized Alliance,,تحالف تمدّن
+IRQ,8881,Q7313133,Renewal List,,قائمة تجديد
+IRQ,7591,Q43033568,National Wisdom Movement,,تيار الحكمة الوطني
+IRQ,5616,Q677505,Patriotic Union of Kurdistan,,Yekêtiy Nîştimaniy Kurdistan
+IRQ,3767,Q3666358,Kurdistan Islamic Union,,الاتحاد الاسلامي الكوردستاني
+IRQ,7837,Q745905,Assyrian Democratic Movement,,ܙܘܥܐ ܕܝܡܘܩܪܛܝܐ ܐܬܘܪܝܐ
+IRL,924,Q661973,Progressive Democrats,PD,An Páirtí Daonlathach
+IRL,8242,Q16000050,Solidarity,Sol,Neart le Chéile
+IRL,1316,Q4774514,Anti H-Block,AHB,
+IRL,8642,Q61090509,Aontú,Aon,
+IRL,4556,Q5001833,Business and Professional Group,BP,
+IRL,1354,Q548562,Clann na Poblachta,CnaP,
+IRL,1024,Q944018,Clann na Talmhan,CnaT,
+IRL,2442,Q1143631,Cumann na nGaedheal,CnaG,
+IRL,4870,Q20682633,Social Democrats,SD,Na Daonlathaithe Sóisialta
+IRL,1172,Q1185856,Democratic Left,DL,Daonlathas Clé
+IRL,1029,Q471405,Democratic Socialist Party,DSP,An Páirtí Sóisialach Daonlathach
+IRL,3209,Q15980830,Direct Democracy Ireland,,
+IRL,2292,Q3776744,Farmers' Party,FP,Páirtí na bhFeirmeoirí
+IRL,1055,Q216517,Fianna Fáil,FF,Fianna Fáil&nbsp;– An Páirtí Poblachtánach
+IRL,1288,Q247135,Fine Gael,FG,Fine Gael
+IRL,1775,Q831015,Green Party,GP,Comhaontas Glas
+IRL,2533,Q10494861,Independent Fianna Fáil,IFF,Fianna Fáil Neamhspleách
+IRL,2441,Q1311653,Irish Parliamentary Party,IPP,Irish Parliamentary Party
+IRL,7273,Q6071313,Irish Unionist Alliance,U,
+IRL,4555,Q4887614,Irish Worker League,IWL,
+IRL,7274,Q7880043,Ulster Unionist Labour Association,,
+IRL,880,Q6541465,Libertas Ireland,,
+IRL,2443,Q1432611,National Centre Party,NCP,
+IRL,1391,Q3776735,National Labour Party,NLP,Páirtí Náisiúnta an Lucht Oibre
+IRL,2115,Q4887430,National League Party,NL,
+IRL,2053,Q6974793,Catholic Democrats,,
+IRL,187,Q3775658,National Progressive Democrats,NPD,
+IRL,8181,Q17100320,Independents 4 Change,I4C,Neamhspleáigh ar son an Athraithe
+IRL,521,Q1111191,Communist Party of Ireland,,Páirtí Cumannach na hÉireann
+IRL,562,Q503614,Labour Party,Lab,
+IRL,208,Q1860218,Workers' Party of Ireland,WP,Páirtí na nOibrithe
+IRL,1448,Q1549074,Socialist Party,SP,
+IRL,242,Q3545406,People Before Profit,PBP,Pobal Roimh Bhrabús
+IRL,4869,Q18720460,Renua Ireland,Ren,
+IRL,2507,Q76382,Sinn Féin,SF,Sinn Féin
+IRL,4,Q76382,Sinn Féin,SF,Sinn Féin
+IRL,8646,Q15980502,Socialist Labour Party,SLP,
+IRL,8241,Q21218940,Solidarity–People Before Profit,PBPS,Pobal Roimh Bhrabús/Dlúthphairtíocht
+IRL,1978,Q2838064,United Left Alliance,,
+ISR,641,Q398134,Agudat Yisrael,,אֲגוּדָּת יִשְׂרָאֵל
+ISR,1398,Q1968280,Ahdut HaAvoda (1919),,אחדות העבודה
+ISR,3129,Q730463,Ale Yarok,,עלה ירוק
+ISR,7077,Q2777648,New Aliyah Party,,
+ISR,7912,Q18913555,Joint List,,הרשימה המשותפת
+ISR,640,Q451237,One Nation,,
+ISR,1663,Q143719,Balad,,"בל""ד"
+ISR,3123,Q2900294,Development and Peace,,
+ISR,3148,Q2891023,Gesher,,
+ISR,3121,Q1524749,Dor,,גיל
+ISR,198,Q2575544,Gahal,,"גח""ל"
+ISR,8749,Q2915102,Independence,,סיעת העצמאות
+ISR,3677,Q1530720,The Jewish Home,,הבית היהודי
+ISR,729,Q1445593,Third Way,,הדרך השלישית
+ISR,421,Q339706,Hadash,,"חד""ש"
+ISR,953,Q1475559,National Union,,האיחוד הלאומי
+ISR,3152,Q2827200,Agriculture and Development,,زراعة وتطوير
+ISR,1036,Q187009,Likud,,ביבי
+ISR,615,Q2579409,Alignment,,המערך
+ISR,8625,Q18669899,Zionist Union,,המחנה הציוני
+ISR,219,Q2635069,Free Centre,,מרכז חופשי
+ISR,1417,Q2383903,Maki,,
+ISR,1167,Q285354,Mizrachi,,המזרחי
+ISR,597,Q2917019,Meri,,
+ISR,613,Q2917054,Hapoel HaMizrachi,,הפועל המזרחי
+ISR,784,Q2777435,Progressive List for Peace,,
+ISR,3127,Q195956,Hatnuah,,התנועה
+ISR,1358,Q2915831,Ratz,,"רַ""ץ"
+ISR,7350,Q60226041,New Right,,הימין החדש
+ISR,3700,Q204044,The Greens,,
+ISR,909,Q2915667,United Religious Front,,החזית הדתית המאוחדת
+ISR,1786,Q2890126,Religious Torah Front,,חזית דתית תורתית
+ISR,1655,Q1070487,Herut,,חרות
+ISR,3192,Q2916522,Herut – The National Movement,,חרות - הלאומית התנועה
+ISR,1560,Q740854,Yemenite Association,,התאחדות התימנים
+ISR,7857,Q60198488,Israel Resilience Party,,
+ISR,1561,Q331852,Kach and Kahane Chai,,כך
+ISR,484,Q39655,Kadima,,קדימה
+ISR,7599,Q61788155,Blue and White,,כחול לבן
+ISR,1722,Q2916230,Progress and Work,,
+ISR,3126,Q773654,Progress and Development,,تقدم وتطور
+ISR,3273,Q18618867,Kulanu,,
+ISR,434,Q2915434,Independent Liberals,,ליברלים עצמאיים
+ISR,3131,Q239951,Meretz,,מרצ
+ISR,1447,Q1501088,National Religious Party,,
+ISR,447,Q2028557,Arab Democratic Party,,
+ISR,678,Q2575588,Liberal Party,,מפלגה ליברלית ישראלית
+ISR,3149,Q2908310,New Liberal Party,,
+ISR,712,Q2575617,Progressive Party,,מפלגה פרוגרסיבית
+ISR,1436,Q210703,Israeli Labor Party,,מפלגת העבודה הישראלית‏‎
+ISR,1061,Q2909407,Centre Party,,מפלגת המרכז
+ISR,169,Q1428864,Mapam,,
+ISR,109,Q1453052,Mapai,,
+ISR,7124,Q2900260,Hashomer Hatzair Workers Party of Palestine,,
+ISR,1664,Q1780708,Moledet,,מולדת
+ISR,425,Q2777636,Morasha,,
+ISR,555,Q2919817,Ometz,,
+ISR,3146,Q46559,Otzma Yehudit,,עוצמה יהודית
+ISR,1491,Q2915662,Poalei Agudat Yisrael,,פועלי אגודת ישראל‎
+ISR,3153,Q2916163,Arab List for Bedouin and Villagers,,القائمة العربية للبدو والفلاحين
+ISR,1337,Q249078,United Arab List,,הרשימה הערבית המאוחדת
+ISR,3151,Q2919169,United Arab List,,
+ISR,1149,Q2916428,Democratic List for Israeli Arabs,,
+ISR,3144,Q2915302,Democratic List of Nazareth,,القائمة الديموقراطية للناصرة
+ISR,907,Q1137968,Maki,,"המפלגה הקומוניסטית הישראלית (מק""י)"
+ISR,770,Q2915343,National List,,רשימה ממלכתית
+ISR,3122,Q2916226,Fighters' List,,רשימת הלוחמים
+ISR,396,Q2915113,Rafi,,רְשִׁימָת פּוֹעַלֵי יִשְׂרָאֵל
+ISR,22,Q2915298,Sephardim and Oriental Communities,,ספרדים ועדות מזרח
+ISR,557,Q1500739,Shinui,,שינוי
+ISR,1616,Q2916425,Cooperation and Brotherhood,,
+ISR,1394,Q2890644,Shlomtzion,,
+ISR,455,Q904635,Shas,,ש״ס
+ISR,7858,Q60472968,Telem,,
+ISR,638,Q607487,Tehiya,,תחייה
+ISR,3147,Q2099890,Ta'al,,"תע""ל"
+ISR,1380,Q2583925,Democratic Movement for Change,,התנועה הדמוקרטית לשינוי
+ISR,745,Q2679208,Tzomet,,
+ISR,920,Q1657077,Women's International Zionist Organization,WIZO,
+ISR,999,Q1556968,Yahad,,
+ISR,3274,Q18668515,HaAm Itanu,,
+ISR,1075,Q1466053,United Torah Judaism,,יהדות התורה
+ISR,3128,Q622716,Yesh Atid,,יֵש עָתִיד
+ISR,1314,Q749411,One Israel,,ישראל אחת
+ISR,1053,Q2453578,Yisrael BaAliyah,,ישראל בעלייה
+ISR,235,Q514442,Yisrael Beiteinu,,ישראל ביתנו
+ISR,3132,Q2776962,Yiud,,
+ISR,7351,Q23304767,Zehut,,זהות
+ISR,1489,Q1887828,General Zionists,,ציונים כלליים
+ITA,8053,Q369707,Alliance of Progressives,,Alleanza dei Progressisti
+ITA,614,Q1747585,Democratic Alliance,AD,Alleanza Democratica
+ITA,813,Q662849,National Alliance,AN,Alleanza Nazionale
+ITA,327,Q793832,Social Action,,Azione Sociale
+ITA,8361,Q28841838,Article 1 – Democratic and Progressive Movement,MDP,Articolo Uno
+ITA,7126,Q1427066,Italian Nationalist Association,,Associazione Nazionalista Italiana
+ITA,6241,Q1046657,House of Freedoms,,Casa delle Libertà
+ITA,8244,Q25648673,CasaPound Italia,CPI,
+ITA,8666,Q28004247,Centrists for Europe,CpE,Centristi per l'Europa
+ITA,1767,Q1054279,Christian Democratic Centre,CCD,Centro Cristiano Democratico
+ITA,2278,Q1952211,Democratic Centre,CD,Centro Democratico
+ITA,7670,Q47389793,Popular Civic List,,Civica Popolare
+ITA,8056,Q5059248,Centre-right coalition,,Coalizione di centrodestra
+ITA,7777,Q25048178,Centre-left coalition,,Coalizione di centro-sinistra
+ITA,763,Q1140350,United Christian Democrats,,Cristiani Democratici Uniti
+ITA,878,Q541679,Democrats of the Left,DS,Democratici di Sinistra
+ITA,934,Q815348,Christian Democracy,DC,Democrazia Cristiana
+ITA,8667,Q2632305,Christian Democracy for Autonomies,,Democrazia Cristiana per le Autonomie
+ITA,279,Q1141788,Democracy Is Freedom – The Daisy,DL,Democrazia è Libertà – La Margherita
+ITA,1327,Q278556,European Democracy,,Democrazia Europea
+ITA,1429,Q1185916,Proletarian Democracy,DP,Democrazia Proletaria
+ITA,6406,Q2949884,Historical Right,,Destra storica
+ITA,7131,Q3733597,The Extreme,,Estrema Sinistra Storica
+ITA,7125,Q601211,Fasci Italiani di Combattimento,,
+ITA,851,Q662502,Federation of the Greens,FdV,Federazione dei Verdi
+ITA,2279,Q15961989,Fare per Fermare il Declino,FiD,Fare per Fermare il Declino
+ITA,1101,Q937319,Tricolour Flame,MSI/FT,Fiamma Tricolore
+ITA,1626,Q215350,Forza Italia,FI,
+ITA,8058,Q14924303,Forza Italia,FI,Forza Italia
+ITA,2280,Q1757843,Brothers of Italy,FdI,Fratelli d'Italia
+ITA,1498,Q2275157,Common Man's Front,,Fronte dell'Uomo Qualunque
+ITA,1179,Q47795,Future and Freedom,FLI,Futuro e Libertà per l'Italia
+ITA,643,Q1185894,The Democrats (Italy),DEM,I Democratici
+ITA,3743,Q1658212,The Sunflower,,Il Girasole
+ITA,1782,Q1658212,The Sunflower,,Il Girasole
+ITA,365,Q47720,The People of Freedom,PdL,Il Popolo della Libertà
+ITA,7671,Q46624077,Together,I,Insieme
+ITA,8057,Q46296,Italy. Common Good,IBC,
+ITA,8641,Q67785862,Italia Viva,IV,Italia Viva
+ITA,8188,Q692736,The Right,,
+ITA,6685,Q15778639,The Other Europe,,L'Altra Europa
+ITA,131,Q1799071,Movement for Democracy – The Net,,La Rete
+ITA,8647,Q3829531,Southern Action League,,Lega d'Azione Meridionale
+ITA,1221,Q47750,Lega Nord,LN,Lega Nord
+ITA,8246,Q44929224,Free and Equal,,Liberi e Uguali
+ITA,744,Q2246227,Lega Lombarda,LL,
+ITA,718,Q958419,Liga Veneta,LV,
+ITA,2134,Q3242650,Bonino List,,Lista Bonino
+ITA,768,Q47768,Italy of Values,IdV,Italia dei Valori
+ITA,3742,Q15980747,Pannella List,,Lista Pannella
+ITA,8648,Q3834914,List for Trieste,,Lista per Trieste
+ITA,1737,Q1134161,The Olive Tree,,L'Ulivo
+ITA,1372,Q1138768,The Union,,L'Unione
+ITA,598,Q3896850,Proletarian Unity Party,PDUP,Partito di Unità Proletaria
+ITA,2046,Q47817,Five Star Movement,M5S,Movimento 5 Stelle
+ITA,1045,Q1233269,Movement for Autonomies,MpA,Movimento per le Autonomie
+ITA,1165,Q577337,European Republicans Movement,MRE,Movimento Repubblicani Europei
+ITA,1696,Q1126102,Italian Social Movement,MSI,Movimento Sociale Italiano
+ITA,2052,Q15196039,New Centre-Right,NCD,Nuovo Centrodestra
+ITA,888,Q1631143,New Italian Socialist Party,,Nuovo Partito Socialista Italiano
+ITA,34,Q461886,Italian Communist Party,PCI,Partito Comunista Italiano
+ITA,817,Q764125,Action Party,Pd/A,Partito d'Azione
+ITA,1635,Q1428001,Party of Italian Communists,,Partito dei Comunisti Italiani
+ITA,1404,Q780997,Communist Refoundation Party,PRC,Partito della Rifondazione Comunista
+ITA,802,Q47729,Democratic Party,PD,Partito Democratico
+ITA,4789,Q3896747,Constitutional Democratic Party (Italy),,Partito Costituzionale Democratico
+ITA,8054,Q1294923,Democratic Party of the Left,PDS,Partito Democratico della Sinistra
+ITA,6303,Q3896759,Labour Democratic Party,DL,Partito Democratico del Lavoro
+ITA,1371,Q764490,Italian Democratic Party of Monarchist Unity,PDIUM,Partito Democratico Italiano di Unità Monarchica
+ITA,7127,Q112739133,Italian Social Democratic Party,,Partito Democratico Sociale Italiano
+ITA,2422,Q3896762,Economic Party,,Partito Economico
+ITA,7129,Q3896773,Democratic Liberal Party,,Italian Democratic Liberal Party
+ITA,1461,Q508733,Italian Liberal Party,PLI,Partito Liberale Italiano
+ITA,684,Q3813340,People's Monarchist Party,,Partito Popolare Monarchico
+ITA,4069,Q139596,National Fascist Party,PNF,Partito Nazionale Fascista
+ITA,773,Q1054567,Monarchist National Party,PNM,Partito Nazionale Monarchico
+ITA,772,Q1826873,Pensioners' Party,,Partito Pensionati
+ITA,2418,Q2717398,Italian People's Party,,Partito Popolare Italiano
+ITA,1701,Q1259087,Italian People's Party,PPI,Partito Popolare Italiano
+ITA,2419,Q30534712,Italian Radical Party,,Partito Radicale Italiano
+ITA,394,Q767560,Italian Republican Party,PRI,Partito Repubblicano Italiano
+ITA,877,Q1299105,Sardinian Action Party,PSd/Az,Partidu Sardu – Partito Sardo d'Azione
+ITA,1126,Q665335,Italian Democratic Socialist Party,PSDI,Partito Socialista Democratico Italiano
+ITA,1505,Q2755002,Italian Socialist Party of Proletarian Unity,PSIUP,Partito Socialista Italiano di Unità Proletaria
+ITA,742,Q590750,Italian Socialist Party,PSI,Partito Socialista Italiano
+ITA,2420,Q2055010,Italian Reform Socialist Party,,Partito Socialista Riformista Italiano
+ITA,1218,Q3896817,Unified PSI–PSDI,,Partito Socialista Unificato
+ITA,6407,Q1265926,United Socialist Party,,Partito Socialista Unitario
+ITA,688,Q2754931,Patto Segni,,Patto Segni
+ITA,6155,Q47090559,More Europe,,Più Europa
+ITA,1519,Q2102613,Pole of Freedoms,,Polo delle Libertà
+ITA,8649,Q3907643,Liberal Democratic Pole,,Polo Liberal Democratico
+ITA,8052,Q463388,Pole for Freedoms,,Polo per le Libertà
+ITA,8055,Q3908389,Populars for Prodi,,Popolari per Prodi
+ITA,8247,Q46217506,Power to the People!,PaP,Potere al Popolo!
+ITA,1449,Q2704736,Radical Party,PR,Partito Radicale
+ITA,259,Q1960994,Italian Renewal,,Rinnovamento Italiano
+ITA,2277,Q2152252,Civil Revolution,,Rivoluzione Civile
+ITA,2281,Q2792033,Civic Choice,SC,Scelta Civica
+ITA,7132,Q21015676,Dissident left-wing,,Sinistra dissidente
+ITA,7031,Q286140,"Left, Ecology and Freedom",SEL,Sinistra Ecologia Libertà
+ITA,1212,Q21405813,Sinistra Italiana,SI,Sinistra Italiana
+ITA,7130,Q2949890,Historical Left,,Sinistra storica
+ITA,750,Q1549174,Italian Democratic Socialists,,Socialisti Democratici Italiani
+ITA,7009,Q2248370,Italian Socialists,SI,Socialisti Italiani
+ITA,1369,Q606620,South Tyrolean People's Party,SVP,Südtiroler Volkspartei
+ITA,1758,Q47781,Union of the Centre,UDC,Unione di Centro
+ITA,734,Q3206451,Democratic Union for the Republic,,Unione Democratica per la Repubblica
+ITA,445,Q4005594,Union of the Centre,,Unione di Centro
+ITA,1464,Q1269803,National Democratic Union,,Unione Democratica Nazionale
+ITA,115,Q1546314,UDEUR Populars for the South,UDEUR,Unione Democratici per l'Europa
+ITA,201,Q47781,Union of the Centre,UDC,Unione di Centro
+ITA,2424,Q20009853,Italian Catholic Electoral Union,UECI,Unione Elettorale Cattolica Italiana
+ITA,7128,Q18216912,Liberal Union,,Unione Liberale
+ITA,548,Q370936,Valdotanian Union,UV,Union Valdôtaine
+ITA,6242,Q1069822,Aosta Valley List,,Vallée d'Aoste
+JAM,2308,Q1539301,Jamaica Labour Party,,
+JAM,3636,Q6972222,National Democratic Movement,,
+JAM,2309,Q1162691,People's National Party,,
+JPN,4482,Q11363607,Chūō Club,,
+JPN,4568,Q25061202,Chūsei Club,,
+JPN,4481,Q11366308,Chūseikai,,
+JPN,4484,Q23074067,Daidō Club,,
+JPN,6722,Q25058601,Dōmei Seisha,SPA,同盟政社
+JPN,8489,Q11414619,Dōshi Club,,同志クラブ
+JPN,4494,Q714797,Taisei Yokusankai,,
+JPN,3215,Q17488856,Party for Japanese Kokoro,,日本のこころ
+JPN,1746,Q232595,Liberal Democratic Party,PLD,自由民主党 / 自民党
+JPN,348,Q6148229,Liberal League,,自由連合
+JPN,8490,Q4981144,"Liberal Party (Japan, 1950)",PL,自由党
+JPN,13,Q60588,Liberal Party,,Jiyūtō
+JPN,1435,Q838626,Liberal Party,PLJ,自由党
+JPN,5305,Q11495237,Kensei Hontō,,
+JPN,4479,Q3062340,Rikken Kokumintō,,立憲国民党
+JPN,5309,Q2915056,Kenseikai,,憲政会
+JPN,6936,Q2915065,Kenseitō,,憲政党
+JPN,6134,Q41040535,Party of Hope,PE,
+JPN,4383,Q2856198,Kokumin Dōmei,,
+JPN,5307,Q11421100,Kokumin Kyōkai,AN,国民協会
+JPN,1100,Q1372123,People's Life First,,Kokumin no Seikatsu ga Daiichi
+JPN,352,Q241325,People's New Party,,
+JPN,1515,Q1061354,Komeito,,公明党
+JPN,1777,Q1355093,Your Party,,
+JPN,8488,Q6444302,Democratic Liberal Party,,民主自由党
+JPN,867,Q1111267,Democratic Socialist Party,PDS,民社党
+JPN,1804,Q200314,Democratic Party of Japan,PDJ,民主党
+JPN,736,Q641600,Japanese Communist Party,JCP,日本共産党
+JPN,778,Q1424871,Japan Democratic Party,,日本民主党
+JPN,3,Q1144146,Japan Socialist Party,PSJ,
+JPN,88,Q1403968,Japan New Party,NPJ,
+JPN,2080,Q1027055,Japan Restoration Party,,
+JPN,2079,Q194683,Tomorrow Party of Japan,,Nippon Mirai no Tō
+JPN,4480,Q2915687,Rikken Dōshikai,,立憲同志会
+JPN,5739,Q11612923,Liberal Party,PL,自由党
+JPN,5740,Q3117297,Rikken Kaishintō,PRC,立憲改進党
+JPN,6935,Q25058625,Rikken Kakushintō,PIC,立憲革新党
+JPN,4367,Q530365,Rikken Minseitō,,立憲民政党
+JPN,6135,Q99233271,Constitutional Democratic Party of Japan,PDC,
+JPN,2439,Q705368,Rikken Seiyūkai,,
+JPN,4564,Q6467366,Labour-Farmer Party,,労働農民党
+JPN,239,Q6517040,Leftist Socialist Party of Japan,,
+JPN,4478,Q11499070,Seiyūhontō,,政友本党
+JPN,492,Q3092168,Socialist Democratic Federation,社民連,社会民主連合
+JPN,136,Q571956,Democratic Party,PD,
+JPN,1524,Q1049247,New Liberal Club,NCL,
+JPN,1109,Q60169,Japan Renewal Party,PR,
+JPN,4107,Q1164105,New Socialist Party,,
+JPN,282,Q1979567,New Frontier Party,PNP,Shinshintō
+JPN,692,Q60658,New Party Nippon,,Shintō Nippon
+JPN,392,Q130700,New Party Sakigake,NPP,
+JPN,5308,Q11499070,Seiyūhontō,,政友本党
+JPN,5741,Q11435492,Taiseikai,GGA,
+JPN,7272,Q714797,Taisei Yokusankai,,
+JPN,4562,Q2322601,Tōhōkai,,東方会
+JPN,91,Q7333752,Rightist Socialist Party of Japan,,
+JEY,7405,Q17507485,Reform Jersey,,
+JOR,6369,Q83150164,National Socialist Party,NSP,الحزب الوطني الاشتراكي
+JOR,4609,Q6942878,Muslim Centre Party,,حزب الوسط الاسلامي
+JOR,6368,Q493302,Hizb ut-Tahrir,,حِزبُ التّحرير
+JOR,4537,Q1674114,Islamic Action Front,,جبهة العمل الإسلامي
+KAZ,8398,Q64780,Alash Party,,Алаш
+KAZ,5907,Q4393618,Asar Party,,
+KAZ,8748,Q27972277,Adal,,Әділ
+KAZ,8397,Q79854,Communist Party of the Soviet Union,CPSU/KPSS,
+KAZ,5627,Q4736147,Kazakhstani Social Democratic Party Auyl,,
+KAZ,3748,Q111077075,Nur Otan,,Nur Otan
+KAZ,5906,Q7165800,People's Union of Kazakhstan Unity,,
+KAZ,5840,Q3508742,Agrarian Party of Kazakhstan,,
+KAZ,5367,Q5124327,Civic Party of Kazakhstan,,Қазақстан азаматтық партиясы
+KAZ,3747,Q1186246,Democratic Party of Kazakhstan Ak Zhol,,Ақ жол Демократиялық Партиясы
+KAZ,4350,Q1780608,Communist Party of Kazakh Soviet Socialist Republic,QKP,Қазақстан Коммунистік партиясы
+KAZ,3749,Q2166484,People's Party of Kazakhstan,QHP,Қазақстанның Халықтық Партиясы
+KAZ,4351,Q5255578,Democratic Choice of Kazakhstan,,Қазақстанның демократиялық таңдауы
+KAZ,6378,Q96405911,Socialist Party of Kazakhstan,QSP,Қазақстан Социалистік партиясы
+KAZ,3750,Q1569210,Nationwide Social Democratic Party,JSDP,Жалпыұлттық социал-демократиялық партия
+KEN,3866,Q15980825,Alliance Party of Kenya,,
+KEN,7609,Q47489380,Amani National Congress,,
+KEN,3860,Q3272441,Democratic Party,,
+KEN,3862,Q5473129,Forum for the Restoration of Democracy – Asili,,
+KEN,3863,Q5473121,Forum for the Restoration of Democracy – Kenya,FORD/Kenya,
+KEN,7971,Q5473122,Forum for the Restoration of Democracy – People,,
+KEN,4081,Q16934870,Grand National Union of Kenya,,
+KEN,6912,Q27963537,Jubilee Party of Kenya,,
+KEN,4083,Q239280,Kenya African Democratic Union,,
+KEN,2316,Q1422517,Kenya African National Union,,
+KEN,6512,Q6392678,Kenya People's Union,,
+KEN,4858,Q2729481,Liberal Democratic Party,,
+KEN,5892,Q6972280,National Development Party,,
+KEN,5834,Q3130920,National Rainbow Coalition,,
+KEN,7970,Q10963557,National Rainbow Coalition – Kenya,,
+KEN,7972,Q7007666,New Forum for the Restoration of Democracy–Kenya,,
+KEN,2360,Q1640905,Orange Democratic Movement,ODM,
+KEN,2361,Q1640905,Orange Democratic Movement,ODM,
+KEN,2359,Q2559675,Party of National Unity,,Party of National Unity
+KEN,3858,Q7398791,Safina,,
+KEN,3867,Q7193584,The National Alliance,,
+KEN,3864,Q7887687,United Democratic Forum,,
+KEN,8872,Q7887695,United Democratic Movement,UDM,
+KEN,3856,Q7889105,United Republican Party,,
+KEN,2362,Q5251223,Wiper Democratic Movement,,
+KIR,5261,Q546130,Pillars of Truth,,Boutokaan te Koaua
+KIR,5262,Q1254124,Protect the Maneaba,,
+KIR,6386,Q6793695,Maurin Kiribati Pati,,Maurin Kiribati Pati
+KIR,6385,Q23058731,Tobwaan Kiribati Party,TKP,Tobwaan Kiribati Party
+PRK,8866,Q49626,Chondoist Chongu Party,,조선천도교청우당
+PRK,6556,Q49624,Korean Social Democratic Party,,조선사회민주당
+PRK,6555,Q49632,Democratic Front for the Reunification of the Fatherland,조국전선,조국통일민주주의전선
+PRK,4712,Q49623,Workers' Party of Korea,WPK,조선로동당
+KOR,4346,Q490133,Creative Korea Party,,창조한국당
+KOR,4345,Q483807,Future Hope Alliance,,미래희망연대
+KOR,4468,Q5047910,National Association (South Korea),,대한독립촉성국민회
+KOR,4466,Q11232736,Korea Nationalist Party,,대한국민당
+KOR,6561,Q15978686,Democratic Party of Korea,,
+KOR,4467,Q5047910,National Association (South Korea),,대한독립촉성국민회
+KOR,7654,Q22262466,People's Party,,국민의당
+KOR,6323,Q16165384,People's Party,,
+KOR,4460,Q625109,Korean National Party,,한국국민당
+KOR,4465,Q483129,Korea Democratic Party,,한국민주당 / 한민당
+KOR,2307,Q20916,Liberty Korea Party,,
+KOR,2306,Q485704,Advancement Unification Party,,
+KOR,4455,Q497541,Liberal Party,,
+KOR,7655,Q20916,Liberty Korea Party,,
+KOR,2545,Q482723,United Liberal Democrats,,자유민주연합
+KOR,6560,Q487520,Justice Party,,
+KOR,4450,Q483462,New Progressive Party,,진보신당
+KOR,5247,Q11242603,Civil Right Party,CRP,민정당
+KOR,4458,Q625991,Democratic Party,,민주당
+KOR,4511,Q483127,Democratic-Republican Party,,
+KOR,4457,Q11547852,Democratic People's Party (South Korea),,
+KOR,4510,Q11242626,Democratic Nationalist Party (South Korea),,민주국민당
+KOR,4342,Q11242645,Democratic Korea Party,,민주한국당
+KOR,894,Q7009697,New Korea Party,,
+KOR,4341,Q489162,Democratic Justice Party,,
+KOR,2546,Q484125,Democratic Labor Party,,
+KOR,4464,Q22794,Democratic Party,,민주당
+KOR,4344,Q23994817,New Democratic Union Party,,
+KOR,2548,Q488952,Democratic Party,,
+KOR,2019,Q11249759,National Congress for New Politics,,
+KOR,4470,Q129634,New Democratic Party,,신민당
+KOR,2543,Q483365,Unified Progressive Party,,
+KOR,2305,Q15070101,Democratic Party,,
+KOR,4509,Q11279167,Reunification Democratic Party,,
+KOR,2452,Q489124,Uri Party,,
+XKX,3703,Q1511179,New Kosovo Alliance,,Aleanca Kosova e Re
+XKX,3243,Q1265971,Alliance for the Future of Kosovo,,Aleanca për Ardhmërinë e Kosovës
+XKX,7895,Q30598971,The Alternative,,Alternativa
+XKX,8274,Q281986,Democratic Party,,Демократска странка
+XKX,8273,Q640380,Democratic Party of Serbia,,Демократска странка Србије
+XKX,3186,Q7908972,Vakat Coalition,,Koalicija Vakat
+XKX,3248,Q1785078,Turkish Democratic Party of Kosovo,,Kosova Demokratik Türk Partisi
+XKX,6621,Q15980790,Movement for Unification,,Lëvizja për Bashkim
+XKX,8275,Q1077031,Liberal Democratic Party,,Либерално демократска партија
+XKX,3704,Q420115,Democratic League of Dardania,,Lidhja Demokratike e Dardanisë
+XKX,2295,Q1164022,Democratic League of Kosovo,,Lidhja Demokratike e Kosovës
+XKX,4765,Q15859034,Civic Initiative for Kosovo,,Nisma Socialdemokrate
+XKX,2294,Q1186316,Democratic Party of Kosovo,,Partia Demokratike e Kosovës
+XKX,5497,Q6317044,Justice Party,,Partia e Drejtësisë
+XKX,3702,Q1471111,New Spirit Party,,Partia Fryma e re
+XKX,3701,Q2264634,Reformist Party ORA,,Partia Reformiste ORA
+XKX,5501,Q939160,Albanian Christian Democratic Party of Kosovo,,Partia Shqiptare Demokristane e Kosovës
+XKX,5500,Q3896861,Social Democratic Party of Kosovo,,Partia Socialdemokrate e Kosovës
+XKX,3249,Q6016749,Independent Liberal Party,,"Самостална либерална странка,"
+XKX,8276,Q752521,Socialist Party of Serbia,SPS,Социјалистичка партија Србије
+XKX,8277,Q7452863,Serbian Liberal Party,,Српска либерална странка
+XKX,5499,Q22205328,Serb List,,
+XKX,8278,Q253586,Serbian Progressive Party,SNS,Српска напредна странка
+XKX,2296,Q29534,Vetëvendosje!,,Lëvizja Vetëvendosje
+KWT,5276,Q6972202,National Democratic Alliance,NDA,التحالف الديمقراطي الوطني
+KWT,5275,Q7229661,Popular Action Bloc,,كتلة العمل الشعبي
+KGZ,7201,Q357262,Democratic Party Adilet,,Демократиялык Партиясы «Әділет»
+KGZ,5382,Q413561,Ak Jol,,Ак Жол элдик партиясы
+KGZ,8484,Q11282919,Akshumkar,,
+KGZ,6341,Q3742736,Forward Kyrgyzstan Party,,"Алга, Кыргызстан!"
+KGZ,5910,Q623457,Ar-Namys,,Ар-Намыс
+KGZ,4527,Q753013,Ata Meken Socialist Party,,Ата-Мекен Социалисттик Партиясы
+KGZ,4529,Q24582,Ata-Zhurt,,Ата-журт
+KGZ,6886,Q21662330,Bir Bol,,Мамлекеттик биримдик жана мекенчилдик саясий партиясы «Бир Бол»
+KGZ,6881,Q42187322,Butun Kyrgyzstan,,Бүтүн Кыргызстан
+KGZ,5613,Q5154410,Communist Party of Kirghiz Soviet Socialist Republic,,Кыргызстан Коммунисттик партиясы
+KGZ,6883,Q21707885,Kyrgyzstan Party,,Кыргызстан
+KGZ,6885,Q22080490,Önügüü–Progress,,Өнүгүү-Прогресс
+KGZ,5612,Q1121018,Party of Communists of Kyrgyzstan,,Кыргызстан Коммунисттеринин Партиясы
+KGZ,4528,Q42116087,Respublika,,Республика
+KGZ,6882,Q24482,Respublika–Ata Zhurt,,Республика–Ата Журт
+KGZ,4526,Q24511,Social Democratic Party of Kyrgyzstan,СДПК,Кыргызстан социал-дemoкратиялык партиясы
+LAO,6038,Q5152972,Committee for the Defence of the National Interests,,
+LAO,6969,Q25302772,Democratic Party,,
+LAO,6964,Q23777602,Lao Neutralist Party,,
+LAO,5203,Q756180,Lao People's Revolutionary Party,,
+LAO,6037,Q23777618,Lao People's Rally,,
+LAO,6970,Q23777620,Lao National Union Party,,
+LAO,6968,Q25302770,Independent Party,,
+LAO,5833,Q6669707,National Progressive Party (Laos),,
+LAO,6967,Q23777617,Peace and Neutrality Party,,
+LAO,6965,Q25303251,Youth Movement,,
+LVA,8393,Q57047035,Development/For!,AP,Attīstībai/Par!
+LVA,6801,Q780221,Committee of the German Baltic Parties,,
+LVA,8079,Q15713073,National Party of Christians,,
+LVA,837,Q5255566,Democratic Center Party,,
+LVA,5707,Q4157658,Democratic Centre,,Demokrātiskais centrs un bezpartejiskie sabiedriskie darbinieki
+LVA,19,Q2021893,"Democratic Party ""Saimnieks""",,
+LVA,897,Q1975768,Motherland,JS,Jaunā Saskaņa
+LVA,7864,Q59461075,Izaugsme,,Izaugsme
+LVA,1531,Q1357342,New Era Party,,Jaunais laiks
+LVA,6355,Q20575851,New Conservative Party,JKP,Jaunā konservatīvā partija
+LVA,1632,Q2021874,New Party,,
+LVA,1000,Q2385748,Demokrāti.lv,,
+LVA,6356,Q28023857,For a Humane Latvia,PCL,Par cilvēcīgu Latviju
+LVA,7863,Q38674389,Movement For!,Par,Kustība Par!
+LVA,5709,Q15713075,Latgalian Christian Farmers' Union,,Kristīgo zemnieku un katoļu partija
+LVA,3213,Q15379125,Latvian Development,LA,Latvijas attīstībai
+LVA,1043,Q1507032,Latvian Way,,Latvijas Ceļš
+LVA,5708,Q15915441,New Farmers-Small Landowners Party,,
+LVA,600,Q1780610,Communist Party of Latvian Soviet Socialist Republic,КПЛ,Latvijas Komunistiskā partija
+LVA,5657,Q1474490,Latvian Russian Union,LKS/Latvian,Latvijas Krievu savienība
+LVA,1789,Q1702540,Latvian National Independence Movement,,
+LVA,708,Q1702540,Latvian National Independence Movement,,
+LVA,1778,Q3401675,Latvia's First Party,,Latvijas Pirmā Partija
+LVA,461,Q1756085,Latvia's First Party/Latvian Way,,Latvijas Pirmā partija/Latvijas Ceļš
+LVA,3194,Q18189957,Latvian Association of Regions,LRA,Latvijas Reģionu apvienība
+LVA,741,Q1573271,Latvian Social Democratic Workers' Party,LSDSP,Latvijas Sociāldemokrātiskā Strādnieku Partija
+LVA,588,Q733925,Socialist Party of Latvia,LSP,Latvijas Sociālistiskā partija
+LVA,1315,Q1807095,Popular Front of Latvia,,
+LVA,373,Q3896841,Latvian Unity Party,,
+LVA,1296,Q1135496,Latvian Green Party,LZP,Latvijas Zaļā partija
+LVA,1702,Q1474484,Latvian Farmers' Union,LZS,Latvijas Zemnieku savienība
+LVA,367,Q966912,Responsibility – Social Democratic Alliance of Political Parties,,
+LVA,860,Q182488,Equal Rights,,
+LVA,8400,Q11813060,Liepāja Party,,Liepājas Partija
+LVA,7619,Q1576026,National Alliance,,Nacionālā Apvienība
+LVA,8081,Q4314935,National Union,,
+LVA,3193,Q16348038,For Latvia from the Heart,,Atmoda
+LVA,176,Q1474490,Latvian Russian Union,LKS/Latvian,Latvijas Krievu savienība
+LVA,393,Q2577092,For a Good Latvia,,Par Labu Latviju!
+LVA,415,Q1679630,Civic Union,,Pilsoniskā savienība
+LVA,8080,Q9392398,Polish-Catholic Latvian Union of Poles,,
+LVA,6357,Q28966907,The Progressives,PRO,Progresīvie
+LVA,627,Q2643041,Society for Other Politics,,Sabiedrība Citai Politikai
+LVA,1056,Q903671,Harmony Centre,SC/Latvian,Saskaņas Centrs
+LVA,87,Q3498680,Social Democratic Party,SDS/2002/2008,Sociāldemokrātiskā partija
+LVA,5976,Q2167704,"Social Democratic Party ""Harmony""",S,"Sociāldemokrātiskā Partija ""Saskaņa"""
+LVA,5787,Q15726764,Union of Social Democrats – Mensheviks and Rural Workers,,
+LVA,1755,Q1250133,People's Party,,Tautas partija
+LVA,1719,Q2337323,National Harmony Party,TSP/Latvian,Tautas Saskaņas partija
+LVA,671,Q1479723,For Fatherland and Freedom/LNNK,,Tēvzemei un Brīvībai/LNNK
+LVA,1704,Q1479723,For Fatherland and Freedom/LNNK,,Tēvzemei un Brīvībai/LNNK
+LVA,852,Q992046,Unity,,Vienotība
+LVA,506,Q164226,All For Latvia!,,Visu Latvijai!
+LVA,701,Q167928,Union of Greens and Farmers,ZZS,Zaļo un Zemnieku savienība
+LVA,1476,Q384826,Reform Party,,Reformu partija
+LBN,3236,Q767681,Syrian Social Nationalist Party,SSNP/English,
+LBN,2565,Q113104,Progressive Socialist Party,PSP,الحزب التقدمي الإشتراكي
+LBN,6039,Q12191666,Constitutional Bloc,,
+LBN,4741,Q2906773,Lebanese National Bloc,NB,الكتلة الوطنية
+LBN,3235,Q1146346,Lebanese Forces,,القوات اللبنانية
+LBN,2564,Q1454007,Free Patriotic Movement,FPM,التيار الوطني الحر
+LBN,7992,Q55604591,Azm Movement,TA,
+LBN,3165,Q452670,Amal Movement,Amal/أمل,حركة أمل
+LBN,8350,Q6737439,Majd Movement,,
+LBN,8940,Q4783242,Arab Socialist Baath Party – Lebanon Region,,
+LBN,2317,Q1822803,Lebanese Democratic Party,LDP,الحزب الديمقراطي اللبناني
+LBN,2566,Q502276,Kataeb Party,Kataeb,حزب الكتائب اللبنانية
+LBN,8351,Q4783205,Arab Liberation Party,DM,تيار الكرامة
+LBN,6391,Q1851961,National Liberal Party,NLP,حزب الوطنيين الأحرار
+LBN,3238,Q41053,Hezbollah,,حزب الله
+LBN,3166,Q1892248,Marada Movement,MM,تيار المردة
+LBN,2562,Q228720,Future Movement,FM,تيار المستقبل
+LBN,5844,Q1475084,March 14 Alliance,,تحالف ١٤ آذار
+LBN,5845,Q636310,March 8 Alliance,,تحالف 8 آذار
+LSO,3766,Q1346132,All Basotho Convention,,
+LSO,5980,Q30611875,Alliance of Democrats,AD,
+LSO,4167,Q512488,Basutoland Congress Party,,
+LSO,4171,Q304032,Basotho National Party,,
+LSO,4169,Q512488,Basutoland Congress Party,,
+LSO,4166,Q1185836,Democratic Congress,,
+LSO,3771,Q939391,Lesotho Congress for Democracy,,
+LSO,4172,Q1314792,Marematlou Freedom Party,,Marematlou Freedom Party
+LSO,4381,Q4229906,Communist Party of Lesotho,,
+LSO,5982,Q30319081,Movement for Economic Change,,
+LBR,5988,Q18712104,Alternative National Congress,,
+LBR,7133,Q1104296,Coalition for the Transformation of Liberia,,
+LBR,4136,Q1125914,Congress for Democratic Change,CDC,
+LBR,5376,Q6541113,Liberia Action Party,,
+LBR,5870,Q6541131,Liberian People's Party,,
+LBR,6502,Q6541099,Liberia Unification Party,,
+LBR,6596,Q6972209,National Democratic Coalition,,
+LBR,4143,Q1520172,National Democratic Party of Liberia,,
+LBR,4142,Q1142176,National Patriotic Party,,
+LBR,5993,Q18712486,People's Unification Party,,
+LBR,5837,Q2164376,True Whig Party,TWP,True Whig Party
+LBR,5991,Q11606780,United People's Party,,
+LBR,4140,Q550159,Unity Party,UP,
+LBY,8825,Q1353163,Union for Homeland,,الإتحاد من أجل الوطن
+LBY,8068,Q8897236,Libyan Arab Socialist Union,,االإتحاد الإشتراكي العربي في ليبيا
+LBY,8826,Q1968205,National Centrist Party,,التيار الوطني الوسطي
+LBY,3638,Q1584261,Justice and Construction Party,,حزب العدالة والبناء
+LBY,8435,Q1148059,National Front Party,,حزب الجبهة الوطنية
+LBY,8712,Q15980857,National Party For Development and Welfare,,الحزب الوطني للتنمية والرفاه
+LBY,3639,Q1338697,National Forces Alliance,,
+LIE,3740,Q1083991,Christian Social Party,,
+LIE,6760,Q15980936,Christian-Social People's Party (Liechtenstein),VP,Christlich-Soziale Volkspartei
+LIE,4178,Q4502447,The Independents,DU,Die Unabhängigen
+LIE,993,Q49670,Progressive Citizens' Party,FBP,Fortschrittliche Bürgerpartei
+LIE,1795,Q49668,Free List,FL,Freie Liste
+LIE,4279,Q1672251,Workers' and Peasants' Party,,Partei der Unselbständig Erwerbenden und Kleinbauern
+LIE,4179,Q333031,Non-Party List,,
+LIE,918,Q49673,Fatherland Union,VU,Vaterländische Union
+LTU,7420,Q79854,Communist Party of the Soviet Union,CPSU/KPSS,
+LTU,102,Q1142007,Labour Party,DP,Darbo partija
+LTU,8088,Q16975726,Farmers' Party,,
+LTU,74,Q1261824,The Way of Courage,,Drąsos kelias
+LTU,1250,Q2641902,Socialist People's Front,,Socialistinis liaudies frontas
+LTU,1026,Q1226938,Young Lithuania,,"Partija ""Jaunoji Lietuva"""
+LTU,776,Q1777648,Christian Democratic Union,,
+LTU,52,Q2641923,Christian Conservative Social Union,,
+LTU,8254,Q1640373,Christian Party,,Krikščionių partija
+LTU,8982,Q64252730,Freedom Party,LP,Laisvės Partija
+LTU,1193,Q1357261,Liberal and Centre Union,,Liberalų ir centro sąjunga
+LTU,377,Q96390507,Lithuanian Nationalist Union,,Lietuvių tautininkų sąjunga
+LTU,5455,Q634790,Lithuanian Centre Party,LCP,Centro partija – Tautininkai
+LTU,1185,Q1824385,Centre Union of Lithuania,,
+LTU,6806,Q3091971,Lithuanian Labour Federation,,Lietuvos Darbo Federacija
+LTU,546,Q63755,Democratic Labour Party of Lithuania,LDDP,Lietuvos demokratinė darbo partija
+LTU,1587,Q1465376,Communist Party of Lithuanian Soviet Socialist Republic,КПЛ,Lietuvos komunistų partija
+LTU,6804,Q3896751,Lithuanian Christian Democratic Party,,
+LTU,1063,Q977089,Lithuanian Christian Democrats,,
+LTU,612,Q2021844,Lithuanian Liberty League,,
+LTU,1410,Q3825677,Lithuanian Liberty Union,,
+LTU,5456,Q17457805,Freedom and Justice,,Laisvė ir teisingumas
+LTU,556,Q1357218,Electoral Action of Poles in Lithuania,LLRA/KŠS,Lietuvos lenkų rinkimų akcija – Krikščioniškų šeimų sąjunga
+LTU,8256,Q3272676,Lithuanian People's Party,,Lietuvos Liaudies Partija
+LTU,1357,Q1824395,Liberal Union of Lithuania,,Lietuvos liberalų sąjunga
+LTU,5779,Q163734,Sąjūdis,LPS/Sąjūdis,Reform Movement of Lithuania
+LTU,753,Q2641943,Lithuanian Union of Political Prisoners and Deportees,,
+LTU,1744,Q1466907,Liberal Movement,LRLS,Lietuvos Respublikos Liberalų sąjūdis
+LTU,168,Q2705461,Lithuanian Russian Union,,Lietuvos rusų sąjunga
+LTU,7352,Q51077566,Social Democratic Labour Party of Lithuania,LRP,Lietuvos regionų partija
+LTU,64,Q4362,Social Democratic Party of Lithuania,LSDP,Lietuvos socialdemokratų partija
+LTU,6808,Q29439,Lithuanian Popular Socialist Democratic Party,,
+LTU,1490,Q285817,Lithuanian Peasant and Greens Union,LVŽS,Lietuvos valstiečių ir žaliųjų sąjunga
+LTU,6811,Q6648410,Lithuanian Popular Peasants' Union,,Lietuvos valstiečių liaudininkų sąjunga
+LTU,21,Q16956773,Lithuanian Peasants Party,,
+LTU,1407,Q15977776,Lithuanian Green Party,,Lietuvos Žaliųjų Partija
+LTU,8392,Q5240377,Modern Christian-Democratic Union,,
+LTU,1800,Q794255,New Union (Social Liberals),,Naujoji sąjunga (socialliberalai)
+LTU,6738,Q28225050,Lithuanian List,,
+LTU,51,Q29266,Party of National Progress,,Tautos pažangos partija
+LTU,347,Q1465363,National Resurrection Party,,Tautos prisikėlimo partija
+LTU,1806,Q5746854,YES,,
+LTU,193,Q81556,Homeland Union – Lithuanian Christian Democrats,TS/LKD,Tėvynės sąjunga – Lietuvos krikščionys demokratai
+LTU,237,Q81517,Order and Justice,TT,Tvarka ir teisingumas
+LTU,6809,Q16354606,Farmers' Association,,
+LTU,6805,Q12663491,Peasant Union,,
+LTU,1291,Q7410008,Samogitian Party,,Žemaitiu partėjė (Samogitian)
+LTU,6807,Q16973458,Democratic Jewish Union,,Žydų demokratinis susivienijimas
+LUX,1114,Q339280,Alternative Democratic Reform Party,,Alternativ Demokratesch Reformpartei
+LUX,1213,Q288172,Citizens' List,,
+LUX,539,Q1344670,Christian Social People's Party,CSV,Chrëschtlech-Sozial Vollekspartei
+LUX,1138,Q767761,The Greens,,Déi Gréng
+LUX,271,Q1270494,The Left,,Déi Lénk
+LUX,300,Q1029792,Democratic Party,DP,Demokratesch Partei
+LUX,552,Q5379896,Enrôlés de Force,,
+LUX,475,Q767761,The Greens,,Déi Gréng
+LUX,1228,Q15978798,Independent Socialist Party (Luxembourg),PSI,
+LUX,1647,Q321673,Communist Party of Luxembourg,KPL,Kommunistesch Partei vu Lëtzebuerg
+LUX,186,Q1070311,Luxembourg Socialist Workers' Party,LSAP,
+LUX,2136,Q1863697,Liberal League,,
+LUX,774,Q7229703,Popular Independent Movement,MIP,
+LUX,995,Q726714,National Movement,,
+LUX,2399,Q2505562,Independent National Party,,
+LUX,2064,Q13512576,Party for Integral Democracy,,
+LUX,2065,Q3079953,Pirate Party Luxembourg,Piraten,Piratepartei Lëtzebuerg
+LUX,2116,Q3246439,Radical Liberal Party,,
+LUX,2118,Q7280460,Radical Socialist Party (Luxembourg),,
+LUX,4445,Q2402740,Party of the Right,RP,Rietspartei
+LUX,898,Q3246842,Social Democratic Party,SdP,Parti Social Démocrate
+LUX,8609,Q463899,Volksdeutsche Bewegung,VdB,Volksdeutsche Bewegung
+LUX,7353,Q55229798,Volt Europa,Volt,
+MKD,8756,Q31360446,The Alliance for the Albanians,ASh,Aleanca për Shqiptarët
+MKD,6395,Q18351105,Democratic Party,,
+MKD,354,Q2491813,Democratic Alternative,DA,Демократска алтернатива
+MKD,4544,Q2705789,Democratic Renewal of Macedonia,,Демократска обнова на Македонија
+MKD,431,Q1785240,Democratic Party of Albanians,,Демократска Партија на Албанците
+MKD,5660,Q3393359,Democratic Party of Turks,,
+MKD,1220,Q1186346,Democratic Union for Integration,,Демократска унија за интеграција
+MKD,5585,Q19604442,Besa Movement,,Lëvizja Besa
+MKD,7311,Q6926620,Movement for All-Macedonian Action,,
+MKD,5760,Q16738440,Citizen Option for Macedonia,,Граѓанска опција за Македонија
+MKD,2449,Q614163,Liberal Party of Macedonia,ЛпМ,Либерална партија на Македонија
+MKD,171,Q683845,Liberal Democratic Party,,Либерално-Демократска Партија
+MKD,3179,Q1717980,National Democratic Revival,,Rilindja Demokratike Kombëtare
+MKD,5462,Q1161630,New Democracy,,
+MKD,2447,Q2705468,New Social Democratic Party,,Нова социјалдемократска Партија
+MKD,1033,Q1591223,Party for Democratic Prosperity,,Партија за демократски просперитет
+MKD,4545,Q3111716,Party for European Future,,Партија за Европска Иднина
+MKD,1508,Q160188,Social Democratic Union of Macedonia,SDSM,Социјалдемократски сојуз на Македонија
+MKD,724,Q2491139,Socialist Party of Macedonia,,Социјалистичка партија на Македонија
+MKD,5764,Q1563709,League of Communists of Macedonia,,Сојуз на комунистите на Македонија
+MKD,5765,Q614163,Liberal Party of Macedonia,ЛпМ,Либерална партија на Македонија
+MKD,5658,Q18386845,Party of Democratic Action–Islamic Path,,
+MKD,1674,Q945717,Internal Macedonian Revolutionary Organization – Democratic Party for Macedonian National Unity,VMRO/DPMNE,Внатрешна македонска револуционерна организација — Демократска партија за македонско национално единство
+MKD,4258,Q539282,Internal Macedonian Revolutionary Organization – People's Party,,ВМРО - Народна Партија
+MDG,5311,Q514599,Association for the Rebirth of Madagascar,AREMA,Antoko Revolisionera Malagasy
+MDG,5373,Q2783589,Judged By Your Work Party,,
+MDG,5370,Q5333394,Economic Liberalism and Democratic Action for National Recovery,,
+MDG,5838,Q936970,Movement for the Progress of Madagascar,,
+MDG,5369,Q4345993,Congress Party for the Independence of Madagascar,,
+MDG,5372,Q7550585,Social Democratic Party of Madagascar and the Comoros,,
+MDG,8438,Q8058262,Young Malagasies Determined,TGV,Tanora malaGasy Vonona
+MDG,5201,Q7800104,Tiako I Madagasikara,,Tiako I Madagasikara
+MWI,3733,Q4732363,Alliance for Democracy,,
+MWI,4846,Q1185876,Democratic Progressive Party,DPP,
+MWI,3732,Q1037389,Malawi Congress Party,MCP,Malawi Congress Party
+MWI,7299,Q7070923,Nyasaland African Congress,,
+MWI,4847,Q2069639,People's Party,PP,
+MWI,3737,Q7314624,Republican Party,,
+MWI,3734,Q775844,United Democratic Front,UDF,
+MWI,4844,Q7887759,United Federal Party,,
+MYS,6344,Q539988,Angkatan Perpaduan Ummah,,
+MYS,8000,Q808206,Barisan Alternatif,,
+MYS,3637,Q808210,Barisan Nasional,BN,Barisan Nasional
+MYS,6430,Q15980898,Malayan Peoples' Socialist Front,SF,Fron Sosialis Rakyat Malaya
+MYS,8021,Q12686725,Gagasan Rakyat,,Gagasan Rakyat
+MYS,4743,Q958983,Malaysian Indian Congress,மஇகா/MIC,
+MYS,7893,Q1570973,Pakatan Rakyat,Pakatan/PR,
+MYS,7999,Q4919308,National Trust Party,AMANAH,
+MYS,8020,Q4454959,Parti Bansa Dayak Sarawak,PBDS,
+MYS,8018,Q795824,Sabah People's United Front,BERJAYA,
+MYS,7092,Q1635641,Parti Bersatu Sabah,PBS,Parti Bersatu Sabah
+MYS,8014,Q6467507,Labour Party of Malaya,Lab/LPM,Parti Buruh Malaya
+MYS,6634,Q17374760,United Democratic Party,,
+MYS,8026,Q7423428,Progressive Democratic Party,PDP,
+MYS,6636,Q3048772,Parti Gerakan Rakyat Malaysia,PGRM/GERAKAN,
+MYS,8019,Q12699609,Parti Hizbul Muslimin Malaysia,HAMIM,
+MYS,2483,Q1547025,Malaysian Islamic Party,PAS,
+MYS,7892,Q20463219,Parti Keadilan Masyarakat Malaysia,PEKEMAS,Parti Keadilan Masyarakat Malaysia
+MYS,2485,Q1756601,People's Justice Party,PKR/KEADILAN,
+MYS,7891,Q7423427,Sarawak National Party,SNAP,
+MYS,8023,Q6540635,Liberal Democratic Party,LDP,
+MYS,6431,Q7449024,Semangat 46,S46,Parti Melayu Semangat 46
+MYS,6890,Q7140287,Parti Negara,Negara,Parti Negara
+MYS,8013,Q456403,Alliance Party,Alliance,
+MYS,5599,Q4918646,Parti Pesaka Bumiputera Bersatu,PBB,
+MYS,7998,Q26871088,Malaysian United Indigenous Party,BERSATU/PPBM,
+MYS,6635,Q1002594,People's Progressive Party,myPPP,
+MYS,8022,Q1349609,Sabah Progressive Party,SAPP,
+MYS,5880,Q1100205,Sarawak United Peoples' Party,SUPP,
+MYS,8015,Q1500043,Parti Rakyat Malaysia,PRM,
+MYS,8027,Q4921498,Parti Rakyat Sarawak,,
+MYS,2486,Q1185837,Democratic Action Party,DAP,
+MYS,8669,Q27547071,Sabah Heritage Party,WARISAN,
+MYS,2484,Q1886920,Malaysian Chinese Association,MCA,马来西亚华人公会
+MYS,8016,Q23777604,Sarawak Chinese Association,SCA,Persatuan Cina Sarawak
+MYS,2318,Q1668154,United Malays National Organisation,UMNO/PEKEMBAR,
+MYS,8024,Q175657,United Progressive People of Kinabalu Organisation,UPKO,
+MYS,8017,Q1243071,United Sabah National Organisation,USNO,
+MDV,5679,Q5269629,Dhivehi Qaumee Party,,
+MDV,5327,Q2477147,Dhivehi Rayyithunge Party,,ދިވެހި ރައްޔިތުންގެ ޕާޓީ
+MDV,8344,Q5527681,Gaumee Itthihaad,,ޤައުމީ އިއްތިހާދު
+MDV,5680,Q7314626,Republican Party,,ޖުމްހޫރީ ޕާޓީ
+MDV,5685,Q17070590,Maldives Development Alliance,,މޯލްޑިވްސް ޑިވެލޮޕްމަންޓް އެލަޔަންސް
+MDV,5329,Q1778600,Maldivian Democratic Party,MDP,ދިވެހިރައްޔިތުންގެ ޑިމޮކްރެޓިކް ޕާޓީ
+MDV,5684,Q7165457,People's Alliance,,
+MDV,7914,Q61750742,People's National Congress,,ޕީޕަލްސް ނެޝެނަލް ކޮންގްރެސް
+MDV,5682,Q7248786,Progressive Party of Maldives,PPM,ޕްރޮގްރެސިވް ޕާރޓީ އޮފް މޯލްޑިވްސް
+MLI,2477,Q2838240,Alliance for Democracy in Mali,,"Alliance pour la Démocratie au Mali – Parti Pan-Africain pour la Liberté, la Solidarité et la Justice"
+MLI,8440,Q16965545,Alliance for Solidarity in Mali,,
+MLI,2478,Q2993172,National Congress for Democratic Initiative,,Congrès National d'Initiative Démocratique
+MLI,6084,Q3366626,Party for National Rebirth,,Le Parti pour la renaissance nationale
+MLI,6085,Q958794,Patriotic Movement for Renewal,MPR,Mouvement Patriotique  pour le Renouveau
+MLI,8028,Q17108756,Party for Democracy and Progress,,
+MLI,6448,Q7633374,Sudanese Regroupment Party,,
+MLI,2319,Q3419939,Rally for Mali,RPM,Rassemblement pour le Mali
+MLI,5374,Q4157657,Democratic Union of the Malian People,,Union démocratique du peuple malien
+MLI,2476,Q3550438,Union for the Republic and Democracy,,Union pour la République et la Démocratie
+MLI,2475,Q1163319,Sudanese Union – African Democratic Rally,,Union Soudanaise-Rassemblement Démocratique Africain
+MLI,8439,Q16938382,Change Party,,
+MLT,62,Q438783,Democratic Alternative,AD,
+MLT,385,Q2168679,Christian Workers Party,CWP,Partit tal-Ħaddiema Nsara
+MLT,15,Q5164299,Constitutional Party,,Partit Kostituzzjonali
+MLT,420,Q16938937,Democratic Action Party,,
+MLT,476,Q16930459,Gozo Party,,Partit Għawdxi
+MLT,515,Q3805716,Imperium Europa,,Imperium Europa
+MLT,1604,Q6744699,Malta Workers Party,,Partit tal-Ħaddiema
+MLT,1487,Q17002036,Democratic Nationalist Party,,
+MLT,7354,Q25338957,Democratic Party,PD,Partit Demokratiku
+MLT,1861,Q1911801,Communist Party of Malta,,Partit Komunista Malti
+MLT,808,Q684886,Labour Party,PL,Partit Laburista
+MLT,699,Q594056,Nationalist Party,PN,Partit Nazzjonalista
+MLT,1899,Q17002029,Democratic Nationalist Party,,Partito Democratico Nazionalista
+MRT,6340,Q4677199,Action for Change,,Action pour le changement
+MRT,5693,Q7165717,People's Progressive Alliance,,Alliance populaire progressiste
+MRT,6339,Q6793708,Mauritanian Popular Front,,Front Populaire
+MRT,6252,Q17002486,El Wiam,PEDS,Parti de l'Entente Démocratique et Sociale
+MRT,6251,Q15980850,Mauritanian Regroupment Party,,Parti de Regroupement Mauritanien
+MRT,5289,Q1698098,Mauritanian People's Party,,حزب الشعب الموريتاني
+MRT,5288,Q3366690,Republican Party for Democracy and Renewal,,Parti Républicain Démocratique pour le Renouvellement
+MRT,5199,Q930378,Rally of Democratic Forces,RFD,Rassemblement des Forces Démocratiques
+MRT,7495,Q7287085,Rally for Democracy and Unity,,Rassemblement pour la Démocratie et l'Unité
+MRT,5896,Q12184844,National Rally for Reform and Development,NRRD,التجمع الوطني للإصلاح و التنمية
+MRT,6071,Q4119039,Union of the Forces of Progress,,
+MRT,8029,Q9091826,Union for Democracy and Progress,,Union pour la Démocratie et le Progrès
+MRT,5819,Q7886485,Union for the Republic,,الإتحاد من أجل الجمهورية
+MRT,6513,Q17009697,Mauritanian Progressive Union,,
+MUS,8853,Q4732476,Alliance of the Future,,
+MUS,5415,Q15980710,Mauritian Solidarity Front,,
+MUS,6457,Q7738242,The Greens,,
+MUS,2460,Q3326727,Mauritian Militant Movement,,Mouvement Militant Mauricien
+MUS,7144,Q6793750,Mauritian Militant Socialist Movement,,
+MUS,7143,Q7314609,Republican Movement,,
+MUS,2464,Q7357460,Rodrigues Movement,MR,
+MUS,3798,Q6851928,Militant Socialist Movement,MSM,Mouvement Socialiste Militant
+MUS,2463,Q7357462,Rodrigues People's Organisation,OPR,Organisation du Peuple Rodriguais
+MUS,3800,Q6793756,Mauritian Social Democrat Party,,Parti Mauricien Social Démocrate
+MUS,2320,Q3366796,MSM,PTr,Parti Travailliste
+MEX,8834,Q495025,Coalition for the Good of All,,Coalición por el Bien de Todos
+MEX,1331,Q10920094,Citizens' Movement,,Movimiento Ciudadano
+MEX,6110,Q15717618,National Regeneration Movement,MORENA,Movimiento Regeneración Nacional
+MEX,696,Q851087,National Action Party,PAN,Partido Acción Nacional
+MEX,1989,Q753453,Authentic Party of the Mexican Revolution,,Partido Auténtico de la Revolución Mexicana
+MEX,216,Q767010,Party of the Democratic Revolution,,Partido de la Revolución Democrática
+MEX,1241,Q540320,Labor Party of Mexico,,Partido del Trabajo
+MEX,4050,Q3979015,Mexican Democratic Party,,Partido Demócrata Mexicano
+MEX,6113,Q6064040,Social Encounter Party,,Partido Encuentro Social
+MEX,7007,Q17624582,Humanist Party,,Partido Humanista
+MEX,5867,Q2788519,Mexican Laborist Party,,Partido Laborista Mexicano
+MEX,8603,Q3366487,Liberal Party,,Partido Liberal
+MEX,1474,Q682969,Institutional Revolutionary Party,,Partido Revolucionario Institucional
+MEX,1345,Q2080372,New Alliance Party,,Partido Nueva Alianza
+MEX,810,Q1803295,Social Democratic Party,,Partido Socialdemócrata
+MEX,446,Q383718,Ecologist Green Party of Mexico,,Partido Verde Ecologista de México
+MDA,7622,Q61086544,NOW Platform,ACUM,ACUM Platforma DA și PAS
+MDA,5239,Q2041112,Popular Front of Moldova,FPM,Frontul Popular din Moldova
+MDA,6503,Q18167214,Unity Movement for Equality in Rights,,
+MDA,3180,Q3624010,Șor Party,ȘOR,Partidul „ȘOR”
+MDA,7904,Q24909066,Party of Action and Solidarity,PAS,Partidul Acțiune și Solidaritate
+MDA,2259,Q542010,Party Alliance Our Moldova,,Alianță Moldova Noastră
+MDA,6971,Q2605592,Communist Party of the Moldavian Soviet Socialist Republic,,Partidul Comunist al Moldovei
+MDA,2260,Q750116,Party of Communists of the Republic of Moldova,PCRM,Партидул Комуништилор дин Република Молдова
+MDA,2265,Q1186294,Democratic Party of Moldova,PDM,Partidul Democrat din Moldova
+MDA,5989,Q4345985,Party of Law and Justice,,
+MDA,2272,Q1822918,Liberal Party,PL,Partidul Liberal
+MDA,3650,Q6974099,National Liberal Party,PNL,Partidul Național Liberal
+MDA,7905,Q22079647,Dignity and Truth Platform Party,PPDA,Partidul Platforma Demnitate și Adevăr
+MDA,2264,Q1811403,Christian-Democratic People's Party,,Partidul Popular Creștin Democrat
+MDA,4119,Q18210808,Party of Rebirth and Conciliation of Moldova,,
+MDA,2555,Q2054893,Social Democratic Party,,Partidul Social Democrat
+MDA,2551,Q4430210,Socialist Party of Moldova,,
+MDA,2553,Q2603304,Party of Socialists of the Republic of Moldova,PSRM,Partidul Socialiștilor din Republica Moldova
+MDA,2552,Q532995,Social Liberal Party,,
+MDA,8763,Q7314695,Our Party,PN,Partidul Nostru
+MDA,3649,Q3027506,Centrist Union of Moldova,,Uniunea Centristă din Moldova
+MCO,7137,Q19604424,Horizon Monaco,,
+MCO,6389,Q16829326,Democratic Union Movement,,Mouvement Union Démocratique
+MCO,6390,Q18619469,Renaissance,,
+MCO,5320,Q2053150,Union for Monaco,,Union monégasque
+MCO,5321,Q3929414,Rally & Issues,,Rassemblement & Enjeux
+MNG,2321,Q1186234,Democratic Party,DP/English,Ардчилсан Нам
+MNG,4902,Q6917539,Motherland Party,,
+MNG,2468,Q945843,Civil Will-Green Party,,Иргэний Зориг–Ногоон Нам
+MNG,2322,Q1127178,Mongolian People's Party,MPP/English,Монгол Ардын Нам
+MNG,7623,Q6899651,Mongolian People's Revolutionary Party,MPRP/English,Монгол Ардын Хувьсгалт Нам
+MNG,5872,Q6899665,Mongolian Social Democratic Party,,Монголын Социал Демократ Нам
+MNG,7925,Q25632520,Mongolian Traditional United Party,MTUP/English,
+MNG,8492,Q17000184,Mongolian National Democratic Party,,
+MNG,7142,Q13561128,Mongolian National Democratic Party (2005),,Монгол Үндэсний Ардчилсан Нам
+MNG,8823,Q16874686,Justice Coalition,,
+MNE,8617,Q27949962,Albanians Decisively,,Shqiptarët të vendosur
+MNE,5661,Q4709066,Albanian Alternative,,Alternativa Shqiptare
+MNE,3255,Q4947380,Bosniak Party,,Bošnjačka stranka
+MNE,3163,Q3323223,Coalition for a European Montenegro,,Evropska Crna Gora
+MNE,6087,Q347411,Democratic Front,,Демократски фронт
+MNE,5469,Q23641777,Democratic Montenegro,,Demokratska Crna Gora
+MNE,6624,Q24007621,Democratic People's Party,,Demokratska narodna partija
+MNE,3162,Q648211,Democratic Party of Socialists of Montenegro,ДПСЧ,Демократска партија социјалиста
+MNE,5487,Q2021687,Democratic Serb Party,,Demokratska srpska stranka
+MNE,3250,Q5255844,Democratic Union of Albanians,,Demokratska unija Albanaca
+MNE,5467,Q23014499,DEMOS,,ДЕМОС
+MNE,3254,Q5255636,Democratic League in Montenegro,,Demokratski savez u Crnoj Gori
+MNE,3253,Q5187103,Croatian Civic Initiative,,Hrvatska građanska inicijativa
+MNE,7624,Q28129639,Key Coalition,,Коалиција Кључ
+MNE,4768,Q1266892,Liberal Party of Montenegro,,Либерална партија Црне Горе
+MNE,3164,Q1279026,Liberal Alliance of Montenegro,,Liberalni savez Crne Gore
+MNE,6972,Q12958667,People's Party,,Народна странка
+MNE,3645,Q1264535,People's Party (Montenegro),,Narodna stranka
+MNE,3251,Q4800,New Democratic Power – FORCA,,Nova demokratska snaga
+MNE,3252,Q1984843,New Serb Democracy,,Нова српска демократија
+MNE,4766,Q2007833,Movement for Changes,,Pokret za promjene
+MNE,4767,Q3862307,Positive Montenegro,,Pozitivna Crna Gora
+MNE,6974,Q7847503,True People's Party,,Права народна странка
+MNE,5488,Q2625533,League of Communists of Montenegro,,Комунистичка партија Црне Горе
+MNE,8410,Q641691,League of Communists of Yugoslavia,СКЮ,Савез комуниста Југославије
+MNE,4079,Q1285187,Union of Reform Forces,,Savez reformskih snaga Jugoslavije
+MNE,5470,Q24908528,Social Democrats of Montenegro,,Socijaldemokrate Crne Gore
+MNE,3185,Q2713129,Social Democratic Party of Montenegro,,Socijaldemokratska partija
+MNE,3104,Q2711827,Socialist People's Party of Montenegro,СНПЦГ,Socijalistička narodna partija
+MNE,5486,Q1264408,Serb People's Party,,Srpska narodna stranka
+MNE,3161,Q7141113,Party of Serb Radicals,,Странка српских радикала
+MNE,5468,Q21029989,United Reform Action,,Ujedinjena reformska akcija
+MSR,5978,Q21188484,Montserrat Labour Party,,
+MSR,5979,Q6926622,Movement for Change and Prosperity,,
+MSR,5981,Q18217168,People's Democratic Movement,,
+MAR,7889,Q3366141,Al Ahd,,
+MAR,5325,Q784586,Authenticity and Modernity Party,,حزب الأصالة والمعاصرة
+MAR,8714,Q3088478,Front of Democratic Forces,,Front des Forces Démocratiques
+MAR,2482,Q477273,Istiqlal Party,,حزب الاستقلال
+MAR,5705,Q3326668,Democratic and Social Movement,,الحركة الديمقراطية والاجتماعية
+MAR,6203,Q3326741,National Popular Movement,,
+MAR,2481,Q1471276,Popular Movement,,ⴰⵎⵓⵙⵙⵓ ⴰⵎⴷⵏⴰⵏ
+MAR,2479,Q1255232,Justice and Development Party,JDP/English,
+MAR,6220,Q1888857,Party of Progress and Socialism,,حزب التقدم والاشتراكية
+MAR,5706,Q3366434,National Democratic Party,,
+MAR,2480,Q1630297,National Rally of Independents,,
+MAR,2324,Q2297130,Socialist Union of Popular Forces,,الاتحاد الاشتراكي  للقوات الشعبية
+MAR,5323,Q3550065,Constitutional Union,,الاتحاد الدستوري
+MAR,5322,Q692325,National Union of Popular Forces,,Union Nationale des Forces Populaires
+MOZ,2314,Q504564,FRELIMO,FRELIMO,Partido FRELIMO
+MOZ,3813,Q668181,Democratic Movement of Mozambique,,Movimento Democrático de Moçambique
+MOZ,3555,Q1685523,"Party for Peace, Democracy, and Development",,
+MOZ,2315,Q1425821,RENAMO,RENAMO,Resistência Nacional Moçambicana
+MMR,7208,Q13080680,21 Party,,
+MMR,4745,Q574639,Anti-Fascist People's Freedom League,,ဖက်ဆစ်ဆန့်ကျင်ရေး ပြည်သူ့လွတ်လပ်ရေး အဖွဲ့ချုပ်
+MMR,5970,Q17068348,Rakhine National Party,ANP,
+MMR,5796,Q2464703,Burma Socialist Programme Party,BSPP/English,မြန်မာ့ဆိုရှယ်လစ်လမ်းစဉ်ပါတီ
+MMR,7139,Q4999351,Burma Workers Party,,
+MMR,5972,Q4381498,National Democratic Force,NDF,
+MMR,7211,Q23649178,Nationalist Party,,
+MMR,5973,Q849603,National League for Democracy,NLD,အမျိုးသားဒီမိုကရေစီအဖွဲ့ချုပ်
+MMR,4748,Q6669743,National United Front,,
+MMR,5974,Q1773249,National Unity Party,NUP/English,
+MMR,7210,Q13074828,Independent Party,,
+MMR,4746,Q25303198,Union Party,,
+MMR,5977,Q4926010,Rakhine Nationalities Development Party,,
+MMR,5975,Q4385984,Shan Nationalities Democratic Party,SNDP,
+MMR,4747,Q25055870,Stable AFPFL,,
+MMR,5818,Q1318070,Union Solidarity and Development Party,USDP,
+MMR,6870,Q23023080,United Hill People's Congress,,
+NAM,5643,Q2823638,Action Christian National,,
+NAM,5642,Q1129391,All People's Party,APP,All People's Party
+NAM,2358,Q1638462,Congress of Democrats,,
+NAM,2356,Q1155803,Democratic Turnhalle Alliance,PDM,
+NAM,6601,Q3251833,National Party of South-West Africa,,Nasionale Party van Suidwes-Afrika
+NAM,2357,Q1126019,National Unity Democratic Organisation,NUDO,
+NAM,4895,Q2129469,Rally for Democracy and Progress,RDP,
+NAM,5641,Q479117,Republican Party,RP,
+NAM,8524,Q1560963,South West Africa National Union,SWANU,
+NAM,2331,Q467711,South-West Africa People's Organization,SWAPO,South-West Africa’s Peoples Organization
+NAM,2355,Q488574,United Democratic Front,UDF,
+NAM,6600,Q7888306,United National South West Party,,
+NRU,8456,Q1186291,Democratic Party of Nauru,,Democratic Party of Nauru
+NRU,8454,Q1964815,Nauru First,,Nauru First Party
+NPL,3759,Q506537,Communist Party of Nepal (Maoist Centre),,नेपाल कम्युनिष्ट पार्टी (माओवादी केन्द्र)
+NPL,3755,Q426963,Communist Party of Nepal (Unified Marxist–Leninist),,नेपाल कम्युनिष्ट पार्टी (एकीकृत मार्क्सवादी-लेनिनवादी)
+NPL,3754,Q111911572,Madhesi Jana Adhikar Forum,MJF/MJFN,"मधेसी जनअधिकार फोरम, नेपाल"
+NPL,8500,Q53700514,Nepal Communist Party,NCP/English,नेपाल कम्युनिष्ट पार्टी
+NPL,3756,Q216660,Nepali Congress,NC,नेपाली काँग्रेस
+NPL,6411,Q1800560,Nepal Workers Peasants Party,NWPP/Nemkipa,नेपाल मजदुर किसान पार्टी
+NPL,8503,Q19679769,Nepal Praja Parishad,,नेपाल प्रजा परिषद
+NPL,6978,Q6994394,Nepal Rashtrabadi Gorkha Parishad,,नेपाल राष्ट्रवादी गोर्खा परिषद
+NPL,6412,Q1776516,Nepal Sadbhawana Party,,नेपाल सदभावना पार्टी
+NPL,7626,Q4589354,Rastriya Janamorcha,,राष्ट्रिय जनमोर्चा
+NPL,7991,Q30635746,Rastriya Janata Party Nepal,RJPN,राष्ट्रिय जनता पार्टी नेपाल
+NPL,8502,Q7295307,Rastriya Praja Party,,
+NPL,3753,Q2632719,Rastriya Prajatantra Party,RPP,राष्ट्रिय प्रजातन्त्र पार्टी
+NPL,8525,Q7413184,Samyukta Prajatantra Party,,संयुक्त प्रजातन्त्र पार्टी नेपाल
+NPL,6724,Q1778556,United People's Front of Nepal,SJMN,संयुक्त जनामोर्चा नेपाल
+NPL,3758,Q947974,Tarai-Madhesh Loktantrik Party,,तराई मधेश लोकतान्त्रिक पार्टी
+NPL,7625,Q25113120,Federal Socialist Forum,FSFN,"संघीय समाजवादी फोरम, नेपाल"
+NLD,714,Q59574,50PLUS,50,
+NLD,8175,Q2320252,General League of Roman Catholic Caucuses,RKSP,
+NLD,994,Q1914664,General Elderly Alliance,AOV,
+NLD,163,Q574747,Anti-Revolutionary Party,ARP,Anti-Revolutionaire Partij
+NLD,5856,Q28147283,DENK,DENK,
+NLD,1110,Q890275,Farmers' Party,BP,Boerenpartij
+NLD,1943,Q2230139,League of Free Liberals,BVL,Bond van Vrije Liberalen
+NLD,1472,Q1054387,Centre Democrats,CD,Centrum Democraten
+NLD,960,Q1054422,Centre Party,CP,Centrumpartij
+NLD,1102,Q143058,Christian Historical Union,CHU,Christelijk-Historische Unie
+NLD,1157,Q273749,Christian Democratic Appeal,CDA,Christen-Democratisch Appèl
+NLD,3720,Q2174467,Christian Democratic Union,CDU,Christelijk-Democratische Unie
+NLD,1459,Q239539,Christian Union,CU,
+NLD,6758,Q3435746,ChristianUnion – Reformed Political Party,,ChristenUnie-SGP
+NLD,459,Q385543,Communist Party of the Netherlands,SDP,Communistische Partij Nederland
+NLD,1533,Q1179915,The Greens,,De Groenen
+NLD,45,Q747910,Democrats 66,D66,Democraten 66
+NLD,921,Q1185905,Democratic Socialists '70,DS/70,Democratisch Socialisten '70
+NLD,2406,Q2603940,Economic League,EB,Economische Bond
+NLD,523,Q954264,Europe Transparent,,
+NLD,1714,Q1341225,Evangelical People's Party,EVP,Evangelische Volkspartij
+NLD,5855,Q28163962,Forum for Democracy,FvD,Forum voor Democratie
+NLD,1602,Q3329377,Reformed Political League,GPV,
+NLD,1537,Q667680,GroenLinks,GL,GroenLinks
+NLD,1888,Q1862182,Hervormd Gereformeerde Staatspartij,HGSP,
+NLD,822,Q1925742,Catholic National Party,KNP,
+NLD,1390,Q1548365,Catholic People's Party,KVP,Katholieke Volkspartij
+NLD,1420,Q1416031,Livable Netherlands,LN,
+NLD,1889,Q2703499,Liberal State Party,LSP,Liberale Staatspartij
+NLD,2128,Q2569059,Liberal Union,LU,Liberal Unie
+NLD,1528,Q1573190,Pim Fortuyn List,LPF,Lijst Pim Fortuyn
+NLD,2402,Q2325518,Middle Party for City and Country,MPSL,
+NLD,1832,Q325186,National Socialist Movement in the Netherlands,NSB,Nationaal-Socialistische Beweging in Nederland
+NLD,369,Q2425987,New Middle Party,NMP,
+NLD,1050,Q574732,Pacifist Socialist Party,PSP,Pacifistisch Socialistische Partij
+NLD,1234,Q275441,Labour Party,PvdA,Partij van de Arbeid
+NLD,1467,Q663535,Party for the Animals,PvdD,Partij voor de Dieren
+NLD,298,Q332739,Party for Freedom,PVV,Partij voor de Vrijheid
+NLD,2102,Q782313,Peasants' League,PB,
+NLD,1581,Q617261,Political Party of Radicals,PPR,Politieke Partij Radikalen
+NLD,3709,Q2606811,Radical League,,
+NLD,172,Q1988184,Reformatory Political Federation,RPF,
+NLD,1902,Q7318855,Revolutionary Socialist Workers' Party,RSAP,
+NLD,3751,Q2673126,Roman Catholic State Party,RKSP,Roomsch-Katholieke Staatspartij
+NLD,2126,Q14475152,Roman Catholic People's Party,RKVP,
+NLD,1187,Q1923234,Roman Catholic Party of the Netherlands,RKPN,
+NLD,1894,Q2558701,Social Democratic Workers' Party,SDAP,Sociaal-Democratische Arbeiderspartij
+NLD,3719,Q385543,Communist Party of the Netherlands,SDP,Communistische Partij Nederland
+NLD,1363,Q849580,Socialist Party,SP,Socialistische Partij
+NLD,1178,Q60172,Reformed Political Party,SGP,Staatkundig Gereformeerde Partij
+NLD,1656,Q2452936,Proud of the Netherlands,TROTS,
+NLD,873,Q3149069,Union 55+,,
+NLD,828,Q239333,People's Party for Freedom and Democracy,VVD,Volkspartij voor Vrijheid en Democratie
+NLD,7355,Q55229798,Volt Europa,Volt,
+NLD,3696,Q1930273,Free Anti Revolutionary Party,VAR,
+NLD,543,Q1751767,Free-thinking Democratic League,VDB,Vrijzinnig Democratische Bond
+NZL,752,Q288838,ACT New Zealand,ACT,
+NZL,716,Q4732275,Alliance,,
+NZL,1741,Q4778800,Aotearoa Legalise Cannabis Party,,
+NZL,1486,Q13586836,Christian Democrat Party,,
+NZL,590,Q3366289,Christian Heritage Party of New Zealand,,
+NZL,240,Q3896732,Communist Party of New Zealand,CPNZ,
+NZL,2040,Q5177383,Country Party,,
+NZL,1353,Q5255632,Democratic Labour Party,DLP,
+NZL,2041,Q7015325,New Zealand Democrat Party,,
+NZL,1099,Q1327761,Green Party of Aotearoa New Zealand,,Green Party of Aotearoa New Zealand
+NZL,150,Q1071444,Jim Anderton's Progressive Party,,
+NZL,1049,Q1048192,New Zealand Labour Party,,Rōpū Reipa o Aotearoa
+NZL,1427,Q1888545,Mana Movement,,Mana Party
+NZL,1716,Q1375170,Māori Party,,Te Pāti Māori
+NZL,8668,Q6792789,Mauri Pacific,,
+NZL,1824,Q204716,New Zealand National Party,,Rōpū Nāhinara o Aotearoa
+NZL,1014,Q3815065,Conservative Party of New Zealand,,
+NZL,1119,Q7005121,NewLabour Party,,
+NZL,591,Q180059,New Zealand First,NZ/First,Aotearoa Tuatahi
+NZL,2095,Q1793808,New Zealand Liberal Party,,
+NZL,870,Q7015568,New Zealand Party,,
+NZL,2094,Q1132236,New Zealand Reform Party,,
+NZL,1374,Q7111934,Outdoor Recreation New Zealand,,
+NZL,911,Q7550492,Social Credit Party,,
+NZL,4072,Q7550558,Social Democratic Party,SDP,
+NZL,7076,Q115110527,Stout–Vogel Ministry,,
+NZL,6130,Q28181034,The Opportunities Party,TOP,
+NZL,940,Q211656,United Future,,Te Rōpū Unaititi Heke Mai
+NZL,1631,Q17067589,United New Zealand,,
+NZL,8343,Q2495287,United Party,,
+NZL,653,Q7912790,Values Party,,
+NIC,1640,Q2729459,Nicaraguan Liberal Alliance,,Alianza Liberal Nicaragüense
+NIC,8619,Q4732427,Alliance for the Republic,,Alianza por la República
+NIC,3655,Q7024450,Nicaraguan Party of the Christian Path,CCN,Partido Camino Cristiano Nicaragüense
+NIC,769,Q27389,Sandinista National Liberation Front,FSLN,Frente Sandinista de Liberación Nacional
+NIC,8875,Q7024444,Nicaraguan Democratic Movement,,
+NIC,395,Q673988,Unión Democrática Renovadora,,Movimiento Renovador Sandinista
+NIC,185,Q1816516,Conservative Party,,Partido Conservador
+NIC,5103,Q5255589,Democratic Conservative Party,,
+NIC,5384,Q2054631,Democratic Party,,Partido Democrático
+NIC,286,Q1422066,Constitutionalist Liberal Party,,Partido Liberal Constitucionalista
+NIC,3656,Q2054647,Independent Liberal Party,,Partido Liberal Independiente
+NIC,7147,Q6016773,Independent Liberal Party for National Unity,,
+NIC,4749,Q2054654,Nationalist Liberal Party,PLN,Partido Liberal Nacionalista
+NIC,7148,Q6993153,Neoliberal Party,,
+NIC,5699,Q7229730,Popular Social Christian Party,,
+NIC,1738,Q7024455,Nicaraguan Resistance Party,,
+NIC,7146,Q9056314,Social Christian Party,,
+NIC,7145,Q3784387,National Opposition Union,,
+NER,2351,Q1621537,Nigerien Alliance for Democracy and Progress,,Alliance nigérienne pour la démocratie et le progrès
+NER,2352,Q1186361,Democratic and Social Convention,,
+NER,5385,Q1421495,Nigerien Democratic Movement for an African Federation,,Mouvement démocratique nigérien pour une fédération africain
+NER,2350,Q1968011,National Movement for the Development of Society,,Mouvement National pour la Société du Développement-Nassara
+NER,7627,Q23047556,Patriotic Movement for the Republic,,Mouvement Patriotique pour la Republique
+NER,8441,Q3366392,African Regroupment Party,,
+NER,2325,Q1968253,Nigerien Party for Democracy and Socialism,,Parti Nigérien pour la Démocratie et le Socialisme-Tarayya
+NER,6253,Q1463756,Party for People's Dignity,,
+NER,5644,Q2054277,Party for National Unity and Development,,
+NER,5347,Q1989838,Nigerien Progressive Party – African Democratic Rally,,Parti Progressiste Nigérien-Rassemblement Démocratique Africain
+NER,5804,Q1020868,Rally for Democracy and Progress,,Rassemblement pour la Démocratie et le Progrès
+NER,5348,Q2305322,Social Democratic Rally,,Rassemblement social démocratique
+NER,5647,Q2045271,Sawaba,,Union des Forces Populaires pour la Démocratie et le Progrès – Sawaba
+NER,5646,Q7886573,Union of Democratic and Progressive Patriots,,
+NER,7301,Q15852091,Union of Nigerien Independents and Sympathisers,,
+NER,5645,Q2494779,Union for Democracy and the Republic,,
+NGA,2353,Q343617,Action Congress of Nigeria,,
+NGA,5355,Q123708,Action Group,,
+NGA,4116,Q112478410,Alliance for Democracy,,
+NGA,2313,Q1432251,All Nigeria Peoples Party,,
+NGA,6144,Q4729271,All Progressives Grand Alliance,,
+NGA,5538,Q4729266,All Progressives Congress,,All Progressives Congress
+NGA,5539,Q5160852,Congress for Progressive Change,,
+NGA,5537,Q6467449,Labour Party,,
+NGA,5353,Q1754230,National Council of Nigeria and the Cameroons,,
+NGA,3552,Q112477489,National Democratic Party,,
+NGA,5349,Q1989646,Nigerian National Democratic Party,,
+NGA,6976,Q1116016,Nigerian Youth Movement,,
+NGA,7476,Q17109246,Northern Elements Progressive Union,,
+NGA,5350,Q7058854,Northern People's Congress,,
+NGA,2354,Q1551163,Peoples Democratic Party,,Peoples Democratic Party [PDP]
+NGA,5354,Q7165739,People's Redemption Party,,
+NGA,510,Q7550561,Social Democratic Party,,
+NGA,3802,Q7888996,United Nigeria People's Party,,
+NGA,5356,Q7893806,Unity Party of Nigeria,,
+NOR,1922,Q1769439,Radical People's Party,,
+NOR,1020,Q3773198,Liberal People's Party,,
+NOR,448,Q190219,Norwegian Labour Party,A/Ap,Arbeiderpartiet
+NOR,101,Q485665,Progress Party,FrP,Fremskrittspartiet
+NOR,1923,Q3505142,Liberal Left Party,,Frisinnede Venstre
+NOR,1124,Q2419495,Norwegian resistance movement,,
+NOR,503,Q586364,Conservative Party of Norway,H,Høyre
+NOR,705,Q1166025,Christian Democratic Party,KrF,Kristelig Folkeparti
+NOR,677,Q1580985,Coastal Party,,Kystpartiet
+NOR,1963,Q1518568,Green Party,MDG,Miljøpartiet De Grønne
+NOR,1924,Q1771177,Moderate Liberal Party,,Moderate Venstre
+NOR,1920,Q167189,Nasjonal Samling,NS,Nasjonal Samling
+NOR,1079,Q587803,Communist Party of Norway,,Norges Kommunistiske Parti
+NOR,1921,Q6515662,Social Democratic Labour Party of Norway,,
+NOR,317,Q2381691,Pensioners' Party,,Pensjonistpartiet
+NOR,3698,Q1512994,Red,,Rødt
+NOR,44,Q2601661,Red Electoral Alliance,,Rød Valgallianse
+NOR,1925,Q6516051,Society Party,,
+NOR,4074,Q1771380,Coalition Party,,Samlingspartiet
+NOR,1072,Q493685,Centre Party,Sp,Senterpartiet
+NOR,1203,Q1771531,Socialist People's Party,,Sosialistisk Folkeparti
+NOR,719,Q488418,Socialist Left Party,SV,Sosialistisk Venstreparti
+NOR,1173,Q500190,Liberal Party,V,Venstre
+OMN,6348,Q4918934,Popular Front for the Liberation of Oman,,الجبهة الشعبية لتحرير عُمان
+PAK,5551,Q1281480,Bangladesh Awami League,AL,বাংলাদেশ আওয়ামী লীগ
+PAK,2326,Q659854,Awami National Party,ANP,
+PAK,6376,Q5176245,Council Muslim League,,کونسل مسلم لیگ
+PAK,5492,Q6082125,Islami Jamhoori Ittehad,IJI,
+PAK,6375,Q1475103,Jamaat-e-Islami,JI,جماعت اسلامی پاکستان
+PAK,2386,Q3133587,Jamiat Ulema-e-Islam,JUI,جمیعت علمائے اسلام
+PAK,6690,Q7238121,Praja Party,,
+PAK,6218,Q38254,Muhajir Qaumi Movement,MQM/H,مہاجر قومی موومنٹ پاکستان
+PAK,5550,Q6942926,Muslim League,,
+PAK,2387,Q1265113,Muttahida Qaumi Movement – London,,
+PAK,7150,Q1410662,Muttahida Majlis-e-Amal,,متحدہ مجلس عمل‎
+PAK,2384,Q799577,Pakistan Muslim League (N),PML/N,پاکِستان مُسلِم لِیگ (ن)
+PAK,2385,Q864345,Pakistan Muslim League (Q),PML/Q,پاکستان مسلم لیگ ق
+PAK,6637,Q7125640,Pakistan Muslim League (J),PML/J,پاکستان مسلم لیگ ج
+PAK,2383,Q186591,Pakistan Peoples Party,PPP,پاکستان پیپلز پارٹی
+PAK,5587,Q284454,Pakistan Tehreek-e-Insaf,PTI,پاکستان تحريک انصاف
+PAK,5868,Q7314629,Republican Party,,ریپبلکن پارٹی
+PSG,8582,Q38799,Hamas,,
+PSE,8702,Q2356410,Palestinian Democratic Union,,
+PSE,6232,Q818618,Democratic Front for the Liberation of Palestine,,الجبهة الديموقراطية لتحرير فلسطين
+PSE,8703,Q2030725,Palestinian National Initiative,,المبادرة الوطنية الفلسطينية
+PSE,8572,Q782016,Third Way,,الطريق الثالث
+PSE,8011,Q38799,Hamas,,
+PSE,6233,Q178888,Fatah,,فتح
+PSE,6234,Q1989200,Palestinian People's Party,PPP,حزب الشعب الفلسطيني
+PSE,8517,Q26683,Palestine Liberation Organization,PLO,منظمة التحرير الفلسطينية
+PAN,59,Q5255581,Democratic Change,,Cambio Democrático
+PAN,5313,Q6974827,National Patriotic Coalition,,Coalición Patriótica Nacional
+PAN,6566,Q17081579,National Liberation Movement,,
+PAN,1555,Q3326718,Nationalist Republican Liberal Movement,,Movimiento Liberal Republicano Nacionalista
+PAN,7154,Q5255538,Democratic Action Party,,
+PAN,5312,Q5163060,Conservative Party,,Partido Conservador
+PAN,5930,Q6467199,Labor and Agrarian Party,,
+PAN,380,Q6974101,National Liberal Party,,Partido Liberal Nacional
+PAN,202,Q628468,Panameñista Party,,Partido Panameñista
+PAN,987,Q2732443,People's Party,,Partido Popular
+PAN,7155,Q6975090,National Progressive Party,,
+PAN,5318,Q7313135,Renewal Party,,
+PAN,6567,Q7314627,Republican Party,,
+PAN,6565,Q6540606,Liberal Civic Resistance Party,,
+PAN,1351,Q1630365,Democratic Revolutionary Party,,Partido Revolucionario Democrático
+PAN,5717,Q7229741,Popular Union Party,,
+PAN,6564,Q7784905,Third Nationalist Party,,
+PAN,7156,Q937341,Patriotic Union,,
+PNG,7628,Q5109510,Christian Democratic Party,,
+PNG,7629,Q29378741,Coalition for Reform Party,,
+PNG,7630,Q6811226,Melanesian Liberal Party,,
+PNG,5259,Q1313018,National Alliance Party,,
+PNG,7631,Q65042442,Our Development Party,,
+PNG,5195,Q2007531,Pangu Party,,
+PNG,7632,Q7119835,PNG Country Party,,
+PNG,7633,Q7133171,Papua New Guinea Party,,
+PNG,5715,Q7165451,People's Action Party,,
+PNG,5257,Q7165524,People's Democratic Movement,,
+PNG,7634,Q7165591,People's Labour Party,,
+PNG,7635,Q28223782,People's Movement for Change,,
+PNG,5716,Q24708,People's National Congress Party,,People's National Congress
+PNG,6307,Q7165671,People's Party,,
+PNG,5256,Q2069646,People's Progress Party,,
+PNG,7636,Q16899473,Social Democratic Party,,
+PNG,6082,Q7844512,Triumph Heritage Empowerment Rural Party,,
+PNG,6306,Q7889106,United Resources Party,,
+PRY,8816,Q1814544,Patriotic Alliance for Change,,Alianza Patriótica por el Cambio
+PRY,384,Q928949,Colorado Party,,Asociación Nacional Republicana – Partido Colorado
+PRY,7638,Q11755876,Frente Guasú,,Frente Guasú
+PRY,2393,Q16886947,Tekojoja People's Movement,,Partido Popular Tekojoja
+PRY,6054,Q3102045,Christian Democratic Party,,Partido Demócrata Cristiano
+PRY,7639,Q3366435,Democratic Progressive Party,,Partido Democrático Progresista
+PRY,571,Q5661540,National Encounter Party,,Partido Encuentro Nacional
+PRY,5081,Q6540713,Liberal Party,,Partido Liberal
+PRY,1245,Q2735114,Authentic Radical Liberal Party,,Partido Liberal Radical Auténtico
+PRY,314,Q3098111,Party for a Country of Solidarity,,Partido País Solidario
+PRY,220,Q3701669,Cherished Nation Party,,Partido Patria Querida
+PRY,5165,Q1477511,Revolutionary Febrerista Party,,Partido Revolucionario Febrerista
+PRY,1339,Q2496554,National Union of Ethical Citizens,,Unión Nacional de Ciudadanos Éticos
+PER,514,Q599149,Popular Action,AP,Acción Popular
+PER,7322,Q16878419,Republican Action,,Accíon Republicana
+PER,4218,Q4732394,Alliance for Progress,APP,Alianza para el Progreso
+PER,529,Q117075460,American Popular Revolutionary Alliance,PAP,Partido Aprista Peruano
+PER,4219,Q5025084,Cambio 90,C90,Cambio 90
+PER,6646,Q23774883,Broad Front,FA,"Frente Amplio por Justicia, Vida y Libertad"
+PER,6377,Q5255861,Democratic Youth Front,,
+PER,788,Q3088482,Center Front,FC,Frente de Centro
+PER,8836,Q3040348,Democratic Front,FREDEMO,Frente Democrático
+PER,5801,Q5391172,National Democratic Front,,
+PER,7408,Q25303253,Hope Front,FE,Frente Esperanza
+PER,4215,Q6016822,Independent Moralizing Front,FIM,Frente Independiente Moralizador
+PER,4216,Q6972815,National Front of Workers and Peasants,,
+PER,7006,Q4693916,FREPAP,FREPAP,Frente Popular Agrícola del Perú
+PER,4214,Q1472820,Popular Force,FP,Fuerza Popular
+PER,8835,Q7170984,Peru Wins,GP,Gana Perú
+PER,8066,Q7551607,Socialist Left,,
+PER,7157,Q5686753,Hayist Bases Movement,MBH,Movimiento de Bases Hayistas
+PER,4751,Q5948160,Peruvian Democratic Movement,,Movimiento Democrático Peruano
+PER,4223,Q5255708,We Are Peru Democratic Party,SP,Partido Democrático Somos Perú
+PER,6557,Q6541886,Liberty Movement,ML,Movimiento Libertad
+PER,8299,Q474074,Civilista Party,,Partido Civil
+PER,7486,Q1972750,Peruvian Communist Party,PCP,Partido Comunista Peruano
+PER,7386,Q5164300,Constitutional Party,,Partido Constitucional
+PER,7323,Q5164308,Constitutional Renewal Party of Peru,,
+PER,4752,Q2723963,Christian Democrat Party,,
+PER,5770,Q7307555,Reformist Democratic Party,,Partido Democrático Reformista
+PER,7158,Q7171161,Peruvian Humanist Political Party,PHP,Partido Humanista Peruano
+PER,8750,Q48796385,Purple Party,PM,Partido Morado
+PER,8604,Q6974797,National Party,,
+PER,345,Q669307,Peruvian Nationalist Party,PNP,Partido Nacionalista Peruano
+PER,1780,Q1234101,Christian People's Party,PPC,Partido Popular Cristiano
+PER,4221,Q8034743,Workers' Revolutionary Party,,
+PER,6152,Q17086663,Revolutionary Socialist Party,PSR,Partido Socialista Revolucionario
+PER,5130,Q7170966,Peru 2000,P2000,Perú 2000
+PER,6647,Q23783750,Peruvians for Change,PPK,Peruanos Por el Kambio
+PER,4861,Q1420702,Possible Peru,PP,Perú Posible
+PER,7004,Q4753656,National United Renaissance,RUNA,Renacimiento Unido Nacional
+PER,4879,Q3456218,National Renewal,RN,Renovación Nacional
+PER,713,Q3427947,National Restoration,RN,Restauración Nacional
+PER,8130,Q7666184,Sí Cumple,SC,Sí Cumple
+PER,290,Q285457,National Solidarity Party,PSN,Partido Solidaridad Nacional
+PER,2554,Q2199044,National Unity,UN,Unidad Nacional
+PER,4217,Q3550398,Odriíst National Union,,
+PER,575,Q2306078,Union for Peru,UPP,Unión por el Perú
+PHL,2391,Q2828960,Akbayan Citizens' Action Party,,
+PHL,7029,Q4701483,Ako Bicol Political Party,,
+PHL,7086,Q5255536,Aksyon Demokratiko,,
+PHL,7044,Q4732438,Alliance of Concerned Teachers,,
+PHL,7042,Q4750957,Anak Mindanao,,
+PHL,7028,Q4750985,Anakpawis,,
+PHL,7026,Q4750262,An Waray,,
+PHL,2390,Q2648064,Bayan Muna,,
+PHL,7038,Q5122625,Citizens' Battle Against Corruption,,
+PHL,7040,Q5167904,Cooperative NATCCO Network Party,,
+PHL,4654,Q17068344,Democratic Party,,
+PHL,7027,Q5512790,GABRIELA,,
+PHL,2465,Q6343824,Kabalikat ng Malayang Pilipino,,
+PHL,7025,Q23777588,Kabataan Partylist,,
+PHL,7324,Q3545706,KALIBAPI,,
+PHL,4248,Q2597155,Kilusang Bagong Lipunan,,Kilusang Bagong Lipunan
+PHL,2466,Q1798571,Nationalist People's Coalition,ННК,
+PHL,4252,Q12966903,Laban ng Demokratikong Pilipino,LDP,Laban ng Demokratikong Pilipino
+PHL,4601,Q6466746,Laban ng Makabayang Masang Pilipino,,
+PHL,5651,Q6474565,Lakas ng Bayan,LABAN,
+PHL,2388,Q6474567,Lakas–CMD,,Lakas–Demokratang Kristiyano at Muslim
+PHL,5653,Q6979769,Nationalist Citizens' Party,,
+PHL,4251,Q7889009,United Opposition,,Nagkakaisang Oposisyon
+PHL,5169,Q6979208,National Unity Party,NUP,Partido ng Pambansang Pagkakaisa
+PHL,4602,Q7140531,Partido Demokratiko Pilipino–Lakas ng Bayan,PDP/Laban,
+PHL,2330,Q1476937,Liberal Party of the Philippines,LP,Partido Liberal
+PHL,2389,Q302210,Nacionalista Party,,Partido Nacionalista
+PHL,4249,Q7140557,Partido para sa Demokratikong Reporma,,
+PHL,4250,Q7246931,Probinsya Muna Development Initiative,PROMDI,
+PHL,4603,Q7248514,Progresista Party,,
+PHL,3654,Q2788486,Pwersa ng Masang Pilipino,,
+PHL,5171,Q7888308,United Nationalist Alliance,,
+PHL,4655,Q7888309,United Nationalist Democratic Organization,UNIDO,
+POL,863,Q416916,Solidarity Electoral Action,,Akcja Wyborcza Solidarność
+POL,1681,Q854452,Nonpartisan Bloc for Support of Reforms,,
+POL,4800,Q505989,Nonpartisan Bloc for Cooperation with the Government,,Bezpartyjny Blok Współpracy z Rządem
+POL,4352,Q2981251,Bloc of National Minorities,,
+POL,8096,Q605468,Communist Party of Poland,,Komunistyczna Partia Polski
+POL,4473,Q2021587,Front of National Unity,,
+POL,4629,Q19600733,Coalition for the Renewal of the Republic - Freedom and Hope,,Koalicja Odnowy Rzeczypospolitej Wolność i Nadzieja
+POL,1615,Q1361968,Confederation of Independent Poland,,Konfederacja Polski Niepodległej
+POL,153,Q183351,Liberal Democratic Congress,,Kongres Liberalno Demokratyczny
+POL,4713,Q1584987,Congress of the New Right,,Kongres Nowej Prawicy
+POL,391,Q3826041,Krajowa Partia Emerytów i Rencistów,,
+POL,4631,Q20740347,Kukiz'15,,
+POL,1588,Q1632729,Left and Democrats,,Lewica i Demokraci
+POL,4871,Q21006495,Lewica Razem,,Lewica Razem (Razem)
+POL,739,Q6541470,Libertas Poland,,
+POL,1768,Q687574,League of Polish Families,,Liga Polskich Rodzin
+POL,4358,Q11789672,National Workers' Party,,Narodowa Partia Robotnicza
+POL,7488,Q11789732,National Workers' Union,,
+POL,4630,Q20738981,Nowoczesna,,
+POL,4472,Q2617519,Camp of National Unity,OZN,Obóz Zjednoczenia Narodowego
+POL,1566,Q1413371,Democratic Party – demokraci.pl,,Partia Demokratyczna – demokraci.pl
+POL,6154,Q1164782,Patriotic Movement for National Rebirth,,Patriotyczny Ruch Odrodzenia Narodowego
+POL,913,Q451401,Freedom and Lawfulness,WiP,Wolność i Praworządność
+POL,1117,Q156868,Civic Platform,PO,Platforma Obywatelska
+POL,41,Q1784503,Poland Comes First,,Polska jest Najważniejsza
+POL,3699,Q2102505,Labor Party,,Polska Partia Pracy – Sierpień 80
+POL,8228,Q687409,Polish Workers' Party,ППР,Polska Partia Robotnicza
+POL,4354,Q210431,Polish Socialist Party,PPS,Polska Partia Socjalistyczna
+POL,8227,Q4371233,Polish Social Democratic Party of Galicia,,Polska Partia Socjalno-Demokratyczna Galicji
+POL,2992,Q15303489,Polska Razem,,Polska Razem
+POL,1286,Q537303,Polish United Workers' Party,PZPR,Polska Zjednoczona Partia Robotnicza
+POL,8098,Q2102649,Polish Christian Democratic Party,,Polskie Stronnictwo Chrześcijańskiej Demokracji
+POL,6757,Q5442008,Polish People's Party (1945–1949),,Polskie Stronnictwo Ludowe
+POL,602,Q218477,Polish People's Party,,Polskie Stronnictwo Ludowe
+POL,4360,Q1471199,"Polish People's Party ""Piast""",,"Polskie Stronnictwo Ludowe ""Piast"""
+POL,4359,Q1154554,"Polish People's Party ""Wyzwolenie""",,"Polskie Stronnictwo Ludowe ""Wyzwolenie"""
+POL,7489,Q18389218,Polish United Party,,
+POL,1535,Q958236,Polish Beer-Lovers' Party,PPPP,Polska Partia Przyjaciół Piwa
+POL,1266,Q11822738,Peasants' Agreement,,
+POL,1649,Q1475388,Centre Agreement,,Porozumienie Centrum
+POL,876,Q94771,Right Wing of the Republic,,Prawica Rzeczypospolitej
+POL,1565,Q156874,Law and Justice,PiS,Prawo i Sprawiedliwość
+POL,1430,Q637464,Silesian Autonomy Movement,,Ruch Autonomii Śląska
+POL,3224,Q16597751,National Movement,,
+POL,1712,Q1271959,Movement for Reconstruction of Poland,,Ruch Odbudowy Polski
+POL,731,Q15052137,Your Movement,,Twój Ruch
+POL,727,Q1128266,Self-Defence of the Republic of Poland,,Samoobrona Rzeczpospolitej Polskiej
+POL,1328,Q980083,Social Democracy of Poland,,Socjaldemokracja Polska
+POL,8224,Q1628291,Social Democracy of the Republic of Poland,,Socjaldemokracja Rzeczypospolitej Polskiej
+POL,57,Q117359153,Democratic Left Alliance,SLD,Sojusz Lewicy Demokratycznej — SLD
+POL,328,Q1337891,United Poland,,Solidarna Polska
+POL,767,Q1003,Solidarity,,Niezależny Samorządny Związek Zawodowy „Solidarność”
+POL,4357,Q3825660,Stronnictwo Chłopskie,,Stronnictwo Chłopskie
+POL,919,Q2351138,Democratic Party,,Stronnictwo Demokratyczne
+POL,8766,Q3366252,Conservative People's Party,,Stronnictwo Konserwatywno-Ludowe
+POL,4353,Q944312,National Party,,Stronnictwo Narodowe
+POL,8226,Q4346035,Labor Party,,Stronnictwo Pracy
+POL,283,Q1270771,Real Politics Union,,Unia Polityki Realnej
+POL,1104,Q1506868,Labour Union,,Unia Pracy
+POL,8268,Q2307945,Freedom Union,,Unia Wolności
+POL,7356,Q61452057,Spring,,Wiosna
+POL,70,Q5109960,Christian National Union,,Zjednoczenie Chrześcijańsko-Narodowe
+POL,929,Q2537981,United People's Party,,Zjednoczone Stronnictwo Ludowe
+POL,4355,Q94430,Popular National Union,,Związek Ludowo-Narodowy
+PRT,7357,Q59325416,Alliance,A,Aliança
+PRT,1742,Q377349,Democratic Alliance,,Aliança Democrática
+PRT,1705,Q1892305,United People Alliance,,Aliança Povo Unido
+PRT,6314,Q25422097,Monarchist Cause,,
+PRT,1308,Q1054298,CDS - Partido Popular,CDS/PP,CDS – Partido Popular
+PRT,8182,Q63645885,Chega,,
+PRT,284,Q572998,Democratic Unity Coalition,,Coligação Democrática Unitária
+PRT,857,Q2054628,Portuguese Workers' Communist Party,,
+PRT,657,Q3052424,Republican and Socialist Front,,Frente Republicana e Socialista
+PRT,1670,Q7165776,People's Socialist Front,,Frente Socialista Popular
+PRT,8640,Q46122950,Liberal Initiative,,Iniciativa Liberal
+PRT,387,Q3800663,Democratic Intervention,,Intervenção Democrática
+PRT,3225,Q16947563,LIVRE,L,LIVRE
+PRT,507,Q6926764,Movement of Socialist Left,,
+PRT,1688,Q613464,Portuguese Democratic Movement,,Movimento Democrático Português
+PRT,1727,Q5899673,Hope for Portugal Movement,MEP,Movimento Esperança Portugal
+PRT,3226,Q1546030,Earth Party,MPT,Movimento o Partido da Terra – Partido da Terra
+PRT,7358,Q20895387,"We, the Citizens!",,
+PRT,310,Q769829,Portuguese Communist Party,PCP,Partido Comunista Português
+PRT,1095,Q605026,New Democracy Party,,
+PRT,181,Q10345705,National Solidarity Party,,Partido da Solidariedade Nacional
+PRT,6312,Q2054820,Republican Union,,
+PRT,5864,Q1783440,Democratic Party,,
+PRT,8101,Q18243216,Catholic Centre Party,,
+PRT,886,Q978086,"Ecologist Party ""The Greens""",,"Partido Ecologista ""Os Verdes"""
+PRT,8269,Q1536126,Humanist Party,,
+PRT,6313,Q1513692,National Republican Party,,Partido Nacional Republicano
+PRT,1106,Q1332539,Workers Party of Socialist Unity,POUS,
+PRT,97,Q2054840,People–Animals–Nature,,Pessoas–Animais–Natureza
+PRT,1359,Q595575,Social Democratic Party,PPD/PSD,Partido Social Democrata
+PRT,1480,Q1851550,People's Monarchist Party,,Partido Popular Monárquico
+PRT,6309,Q1412211,Progressive Party,PP,
+PRT,6308,Q2137407,Regenerator Party,PR,
+PRT,6311,Q75660,Liberal Regenerator Party,PRL,
+PRT,1600,Q980864,Democratic Renewal Party,,Partido Renovador Democrático
+PRT,6316,Q2054732,Reconstitution Party,,
+PRT,8103,Q3366682,Democratic Leftwing Republican Party,,
+PRT,5865,Q1720273,Evolutionist Party,,
+PRT,6315,Q2054660,Republican Liberal Party,,
+PRT,6317,Q847883,Nationalist Republican Party,,Partido Republicano Nacionalista
+PRT,7325,Q2054740,Portuguese Republican Party,,Partido Republicano Português
+PRT,655,Q847263,Socialist Party,PS,Partido Socialista
+PRT,375,Q2054807,Revolutionary Socialist Party,PSR,
+PRT,5939,Q18166125,Portugal Alliance,,Portugal à Frente
+PRT,1301,Q3112915,Leftwing Union for the Socialist Democracy,,
+PRT,896,Q2119074,People's Democratic Union,,União Democrática Popular
+PRT,4753,Q954010,National Union,,União Nacional
+PRI,3668,Q19683,Puerto Rican Independence Party,,Partido Independentista Puertorriqueño
+PRI,3670,Q1076562,New Progressive Party,,Partido Nuevo Progresista
+PRI,3669,Q199319,Popular Democratic Party,PPD,Partido Popular Democrático
+PRI,3667,Q7258663,Puerto Ricans for Puerto Rico Party,,
+PRI,6979,Q7314713,Republican Union,,
+ROU,5662,Q26934816,Alliance of Liberals and Democrats Party,ALDE,Alianța Liberalilor și Democraților
+ROU,8983,Q97193048,Alliance for the Union of Romanians,AUR,Alianța pentru Unirea Românilor
+ROU,5940,Q7333568,Right Romania Alliance,,Alianţa România Dreaptă
+ROU,192,Q2420523,Romanian Democratic Convention,CDR,
+ROU,2473,Q3076858,Civic Force,,Forța Civică
+ROU,2454,Q698997,Democratic Forum of Germans in Romania,FDGR,Forumul Democrat al Germanilor din România
+ROU,276,Q2891183,Democratic National Salvation Front,FDSN,
+ROU,7162,Q1470070,Ploughmen's Front,,Frontul Plugarilor
+ROU,6767,Q303668,National Renaissance Front,FRN,Frontul Renașterii Naționale
+ROU,6765,Q153448,Iron Guard,,Legiunea Arhanghelul Mihail
+ROU,6764,Q6273663,National-Christian Defense League,LANC,Liga Apărării Național Creștine
+ROU,6768,Q1162156,Hungarian People's Union,MNSZ,Magyar Népi Szövetség
+ROU,173,Q948658,Party of the Roma,PRPE,Partida Romilor „Pro Europa”
+ROU,916,Q1904908,Romanian ethnic minorities parties,GPMN,Grupul parlamentar al minorităţilor naţionale
+ROU,7035,Q1424442,Romanian Socialist Party,,Partidul Socialist Român
+ROU,5773,Q256121,Romanian Communist Party,PCR,Partidul Comunist Român
+ROU,6769,Q2307833,Conservative Party,,Partidul Conservator
+ROU,7159,Q18572497,Conservative-Democratic Party,,Partidul Conservator-Democrat
+ROU,1443,Q783621,Conservative Party,PC,Partidul Conservator
+ROU,1715,Q13359938,Democratic Party,PD,Partidul Democrat
+ROU,660,Q852402,Democratic Liberal Party,PDL,Partidul Democrat-Liberal
+ROU,1373,Q2733751,Ecologist Party of Romania,PER,Partidul Ecologist Român
+ROU,7160,Q831042,German Party,,
+ROU,1579,Q3366297,National Initiative Party,PIN,Partidul Inițiativa Națională
+ROU,874,Q2054870,Liberal Democratic Party,PLD,Partidul Liberal Democrat
+ROU,3223,Q17488158,Liberal Reformist Party (Romania),PLR,Partidul Liberal Reformator
+ROU,3210,Q15732550,People's Movement Party,PMP,Partidul Mișcarea Populară
+ROU,6766,Q6270876,National Christian Party,PNC,Partidul Național Creștin
+ROU,8402,Q2064811,Democratic Nationalist Party,PN/D,Partidul Naționalist-Democrat
+ROU,481,Q686228,National Liberal Party,PNL,Partidul Național Liberal
+ROU,6762,Q6974094,National Liberal Party-Brătianu,,Partidul Național Liberal–Brătianu
+ROU,7163,Q22673370,National Liberal Party–Tătărescu,,Partidul Național Liberal
+ROU,6761,Q1226156,Hungarian Party,,Partidul Naţional Maghiar
+ROU,7164,Q18737177,National Popular Party,,Partidul Național Popular
+ROU,6770,Q2220114,Romanian National Party,PNR,Partidul Național Român
+ROU,5450,Q1855102,National Peasants' Party,,Partidul Național Țărănesc
+ROU,1750,Q259887,Christian-Democratic National Peasants' Party,PNȚCD,Partidul Național Țărănesc Creștin Democrat
+ROU,296,Q2054875,New Generation Party,PNG/CD,Partidul Noua Generație - Creștin Democrat
+ROU,5449,Q7165679,People's Party,,Partidul Poporului
+ROU,2474,Q866275,People's Party – Dan Diaconescu,PP/DD,Partidul Poporului - Dan Diaconescu
+ROU,1305,Q828039,Greater Romania Party,PRM,Partidul România Mare
+ROU,5854,Q22261089,United Romania Party,PRU,Partidul România Unită
+ROU,120,Q752435,Social Democratic Party,PSD,Partidul Social Democrat
+ROU,1034,Q2917689,Romanian Social Democratic Party,PSDR,
+ROU,1217,Q3827065,Socialist Party of Labour,PSM,
+ROU,6773,Q7551705,Socialist Party of Romania,,Partidul Socialist din România
+ROU,6772,Q7158424,Peasants' Party,PȚ,Partidul Țărănesc
+ROU,6771,Q4896392,Bessarabian Peasants' Party,,Partidul Țărănesc din Basarabia
+ROU,6763,Q18639621,Peasants' Party–Lupu,,Partidul Țărănesc–Lupu
+ROU,1451,Q835213,Romanian National Unity Party,PUNR,
+ROU,7033,Q929207,Green Party,PV,Partidul Verde
+ROU,7359,Q47454194,PRO Romania,PRO,PRO România
+ROU,1105,Q266582,Democratic Union of Hungarians in Romania,UDMR,Romániai Magyar Demokrata Szövetség
+ROU,1541,Q962976,National Union for the Progress of Romania,UNPR,Uniunea Națională pentru Progresul României
+ROU,5969,Q27108508,Save Romania Union,USR,Uniunea Salvați România
+ROU,5941,Q797760,Social Liberal Union,USL,Uniunea Social Liberală
+RUS,2235,Q396170,Agrarian Party of Russia,APR/English,Аграрная партия России
+RUS,2244,Q210692,A Just Russia,SRZP,Справедливая Россия — За правду
+RUS,6759,Q4229942,Communists of Russia,CPCR/English,Коммунисты России
+RUS,2238,Q1186305,Democratic Party of Russia,,Демократическая партия России
+RUS,2253,Q4157654,Democratic Choice of Russia,DVR/English,Демократический выбор России
+RUS,2236,Q192187,Communist Party of the Russian Federation,CPRF/English,
+RUS,4784,Q79854,Communist Party of the Soviet Union,CPSU/KPSS,
+RUS,2237,Q3920212,Congress of Russian Communities,CRC/English,РОДИНА — Конгресс русских общин
+RUS,7302,Q155820,Constitutional Democratic Party,,Конституционно-демократическая партия
+RUS,2245,Q212115,LDPR,LDPR/English,
+RUS,2247,Q4488786,Our Home – Russia,NDR/English,Наш дом – Россия
+RUS,2240,Q1958474,Fatherland – All Russia,OVR,Отечество – Вся Россия
+RUS,2249,Q4346024,Party of Russian Unity and Accord,PRES/English,Партия российского единства и согласия
+RUS,6739,Q1513573,Party of Growth,,Партия Роста
+RUS,7409,Q1958435,Party of Russia's Rebirth,,Партия возрождения России
+RUS,7309,Q3920216,Party of Peaceful Renovation,,
+RUS,8362,Q584643,Patriots of Russia,,Патриоты России
+RUS,7304,Q2454674,Progressive Party,,Прогрессивная партия
+RUS,2248,Q1559990,People's Freedom Party,РПРФ,Партия народной свободы
+RUS,2246,Q1190255,Rodina,,
+RUS,5822,Q2634417,"Russian Ecological Party ""The Greens""",REP/The/Greens/English,Российская экологическая партия «Зелёные»
+RUS,2252,Q15332,Yabloko,,
+RUS,5823,Q1435537,Russian Pensioners' Party,RPPSJ/English,Российская партия пенсионеров за социальную справедливость
+RUS,5547,Q1021156,Civilian Power,,Гражданская сила
+RUS,7305,Q217009,Socialist Revolutionary Party,,
+RUS,2255,Q686098,Union of Right Forces,SPS/English,Союз правых сил
+RUS,7303,Q1570527,Trudoviks,,
+RUS,7310,Q2423941,Ukrainian Socialist-Revolutionary Party,,
+RUS,7306,Q1470891,Union of October 17,,Союз 17 Октября
+RUS,2256,Q151469,United Russia,Forenede/Rusland,Единая Россия
+RUS,2242,Q1957669,Unity,,Единство
+RWA,3283,Q690240,Rwandan Patriotic Front,,Front Patriotique Rwandais
+RWA,8442,Q3326675,Democratic Republican Movement,,Mouvement démocratique républicain
+RWA,6055,Q957943,National Republican Movement for Democracy and Development,,Mouvement républicain national pour la démocratie et le développement
+RWA,5701,Q5109515,Christian Democratic Party,,Parti Démocrate Centriste
+RWA,7643,Q6082436,Islamic Democratic Party,,Parti Démocratique Idéal
+RWA,5330,Q912006,Parmehutu,Parmehutu,Parti du Mouvement de l'Emancipation Hutu
+RWA,3657,Q3043218,Liberal Party,,Parti Libéral
+RWA,7644,Q766491,Party for Progress and Concord,,Parti pour le Progrès et la Concorde
+RWA,3658,Q3366714,Social Democratic Party,,Parti Social Démocrate
+RWA,7995,Q7550737,Social Party Imberakuri,,Ishyaka ry’Imberakuri Riharanira Imibereho Myiza
+RWA,7645,Q3366774,Rwandese Socialist Party,,Parti Socialiste Rwandais
+RWA,7996,Q3366824,Democratic Green Party of Rwanda,,
+RWA,7642,Q5255847,Democratic Union of the Rwandan People,,Union Démocratique du Peuple Rwandais
+RWA,5328,Q7885867,Union Nationale Rwandaise,UNAR,Union nationale rwandaise
+KNA,4054,Q4115484,Concerned Citizens' Movement,,
+KNA,4060,Q4115493,Nevis Reformation Party,,
+KNA,4058,Q3102757,People's Action Movement,PAM,
+KNA,5964,Q22080592,People's Labour Party,,
+KNA,4056,Q250738,Saint Kitts and Nevis Labour Party,,
+KNA,4057,Q7401602,Saint Kitts Democratic Party,,
+KNA,4055,Q7889041,United People's Party,,
+LCA,3778,Q7165725,People's Progressive Party,,
+LCA,3784,Q1292804,Saint Lucia Labour Party,,
+LCA,3776,Q1292795,United Workers Party,,
+VCT,4259,Q1255291,New Democratic Party,,
+VCT,4261,Q7165702,People's Political Party,,
+VCT,4262,Q7402278,Saint Vincent Labour Party,,
+VCT,4268,Q1277617,Unity Labour Party,,
+WSM,4176,Q1256720,Human Rights Protection Party,,Vaega Faaupufai e Puipuia Aia Tatau a Tagata
+WSM,4174,Q1564615,Samoan Democratic United Party,,
+WSM,5198,Q16148179,Samoan National Development Party,,
+WSM,4175,Q7688972,Tautua Samoa Party,TSP,Vaega Faaupufai le Tautua Samoa
+SMR,3843,Q3612389,Sammarinese National Alliance,,Alleanza Nazionale Sammarinese
+SMR,3846,Q441650,Popular Alliance,,Alleanza Popolare
+SMR,7172,Q4789012,Arengo and Freedom,,Arengo e Libertà
+SMR,3830,Q3326620,Centre Democrats,,Democratici di Centro
+SMR,7171,Q5411492,Euro-Populars for San Marino,,Europopolari per San Marino
+SMR,6728,Q22031505,Ideas in Motion,,
+SMR,5960,Q17636764,Civic 10,Civico10,Movimento Civico10
+SMR,3832,Q3877750,We Sammarinese,,Noi Sammarinesi
+SMR,3833,Q44066,New Socialist Party,,Nuovo Partito Socialista
+SMR,5491,Q1935264,Sammarinese Communist Party,,Partito Comunista Sammarinese
+SMR,3835,Q3366352,Party of Democrats,,Partito dei Democratici
+SMR,3837,Q44102,Party of Socialists and Democrats,PSD,Partito dei Socialisti e dei Democratici
+SMR,5490,Q44282,Sammarinese Christian Democratic Party,,Partito Democratico Cristiano Sammarinese
+SMR,6731,Q3896764,Sammarinese Fascist Party,,Partito Fascista Sammarinese
+SMR,6729,Q7409650,Sammarinese People's Party,,Partito Popolare Sammarinese
+SMR,7167,Q3896801,Sammarinese Democratic Progressive Party,,Partito Progressista Democratico Sammarinese
+SMR,7170,Q3896810,Socialist Party,PS,Partito Socialista
+SMR,6733,Q3896811,Sammarinese Independent Democratic Socialist Party,,Partito Socialista Democratico Indipendente Sammarinese
+SMR,3840,Q2707282,Sammarinese Socialist Party,,Partito Socialista Sammarinese
+SMR,5489,Q7889159,United Socialist Party,,
+SMR,3844,Q3859936,Sammarinese People,,Popolari Sammarinesi
+SMR,5963,Q25399163,RETE Movement,RETE,Movimento Civico RETE
+SMR,5694,Q578424,United Left,SU,Sinistra Unita
+SMR,3842,Q20966638,Socialists for Reform,,
+SMR,6730,Q7409649,Sammarinese Democratic Union,,Unione Democratica Sammarinese
+SMR,5962,Q716379,Union for the Republic,,Unione per la Repubblica
+SMR,3845,Q4004930,Sammarinese Union of Moderates,,Unione Sammarinese dei Moderati
+STP,5340,Q2788422,Independent Democratic Action,ADI,Acção Democrática Independente
+STP,6604,Q7098627,Opposition Democratic Coalition,,
+STP,5331,Q1276673,Movement for the Liberation of São Tomé and Príncipe/Social Democratic Party,MLSTP/PSD,Movimento de Libertação de São Tomé e Príncipe – Partido Social Democrata
+STP,6143,Q1566188,Force for Change Democratic Movement – Liberal Party,,
+STP,5332,Q3463962,Democratic Convergence Party – Reflection Group,,
+STP,8710,Q7886575,Union of Democrats for Citizenship and Development,,
+SAU,6331,Q3366265,Arab Socialist Action Party – Arabian Peninsula,,حزب العمل الاشتراكي العربي ـ الجزيرة العربية
+SAU,6299,Q18379591,National Revolutionary Party of Afghanistan,,حزب انقلاب ملی
+SEN,2379,Q2217942,Alliance of the Forces of Progress,,Alliance des forces de progrès
+SEN,5766,Q2838226,Alliance for the Republic,,Alliance pour la république
+SEN,2382,Q489541,And-Jëf/African Party for Democracy and Socialism,,
+SEN,7315,Q2364065,Senegalese Democratic Bloc,,
+SEN,7313,Q2906761,Senegalese Popular Bloc,,
+SEN,5958,Q3088571,Front for Socialism and Democracy/Benno Jubël,,
+SEN,7087,Q3240540,Democratic League/Movement for the Labour Party,,
+SEN,6461,Q7450474,Senegalese Solidarity Party,,
+SEN,2381,Q2752676,Party of Independence and Labour,,
+SEN,2329,Q1351653,Senegalese Democratic Party,,Parti Démocratique Sénégalais
+SEN,8933,Q3366450,Senegalese Democratic Party – Renewal,,
+SEN,5637,Q3366342,Party for Truth and Development,,
+SEN,7314,Q3366783,Senegalese Party of Socialist Action,,
+SEN,2380,Q2054438,Socialist Party of Senegal,,Parti socialiste du Sénégal
+SEN,7316,Q1332068,French Section of the Workers' International,СФИО,Section française de l'Internationale ouvrière
+SEN,6462,Q3550446,Union for Democratic Renewal,URD,
+SRB,7173,Q4693754,Agrarian Party,,Земљорадничка странка
+SRB,3173,Q24084648,Justice and Reconciliation Party,,Stranka pravde i pomirenja
+SRB,7966,Q1278390,Christian Democratic Party of Serbia,,Демохришћанска Странка Србије
+SRB,4135,Q2840416,Democratic Alternative,,
+SRB,2188,Q1186211,Democratic Opposition of Serbia,,Демократска oпозиција Cрбије
+SRB,8571,Q648211,Democratic Party of Socialists of Montenegro,ДПСЧ,Демократска партија социјалиста
+SRB,5393,Q1277089,Democratic Party,,Демократска странка
+SRB,2189,Q281986,Democratic Party,,Демократска странка
+SRB,2190,Q640380,Democratic Party of Serbia,,Демократска странка Србије
+SRB,7968,Q5255571,Democratic Centre,,
+SRB,6150,Q3866585,Democratic Movement of Serbia,DEPOS,Демократски покрет Србије
+SRB,5379,Q20434676,Enough is Enough,,
+SRB,2193,Q913179,G17 Plus,,Г17 плус
+SRB,2202,Q1275870,Civic Alliance of Serbia,,Грађански савез Србије
+SRB,5392,Q638194,Croatian Peasant Party,HSS,Hrvatska seljačka stranka
+SRB,6625,Q1559559,United Serbia,,Јединствена Србија
+SRB,6626,Q3961877,Yugoslav Left,,Југословенска Левица
+SRB,5696,Q259457,Yugoslav Muslim Organization,,"Jugoslavenska Muslimanska Organizacija, JMO"
+SRB,6794,Q6590291,Yugoslav National Party,,Jugoslavenska nacionalna stranka
+SRB,6795,Q116009,Yugoslav Radical Union,,Југословенска радикална заједница
+SRB,2182,Q7939888,Vojvodina Coalition,,Коалиција Војводина
+SRB,6788,Q12752963,Conservative Party,,Конзервативна странка
+SRB,8363,Q113303457,Serbian Left,,Levica Srbije
+SRB,6789,Q12033325,Liberal Party (Serbia),,Либерална странка
+SRB,2196,Q1077031,Liberal Democratic Party,,Либерално демократска партија
+SRB,4769,Q261528,League of Social Democrats of Vojvodina,,Лига социјалдемократа Војводине
+SRB,5394,Q1282536,People's Radical Party,,Народна радикална странка
+SRB,6627,Q1265313,People's Peasant Party,,Народна сељачка странка
+SRB,2197,Q1252265,Liberals of Serbia,,Либерали Србије
+SRB,7874,Q17098387,New Party,,
+SRB,8131,Q1203656,German Party,,
+SRB,2179,Q1276996,Party of United Pensioners of Serbia,PUPS,Партија уједињених пензионера Србије
+SRB,2195,Q1561673,Let's Get Serbia Moving,,Александар Вучић — за нашу децу
+SRB,8364,Q47463814,Movement of Free Citizens,,Покрет слободних грађана
+SRB,5483,Q389698,Strength of Serbia Movement,,Покрет снага Србије – БК
+SRB,6558,Q11155601,Movement of Socialists,,Покрет социјалиста
+SRB,2174,Q3454797,Reformists of Vojvodina,,Реформисти Војводине
+SRB,6741,Q1252274,Independent Democratic Party,,Самостална демократска странка
+SRB,7174,Q6016354,Independent Agrarian Party,,
+SRB,5391,Q641691,League of Communists of Yugoslavia,СКЮ,Савез комуниста Југославије
+SRB,8403,Q2424039,League of Communists of Serbia,,Savez komunista Srbije
+SRB,8526,Q1285187,Union of Reform Forces,,Savez reformskih snaga Jugoslavije
+SRB,6740,Q1276547,Slovene People's Party,,Slovenska ljudska stranka
+SRB,7965,Q3487389,Social Democracy,,
+SRB,5357,Q1283367,Social Democratic Party,,
+SRB,4771,Q1273056,Social Democratic Party of Serbia,,Социјалдемократска партија Србије
+SRB,4770,Q15732720,Social Democratic Party,,Социјалдемократска странка
+SRB,5400,Q1263608,Social Democratic Union,,Социјалдемократска унија
+SRB,2178,Q752521,Socialist Party of Serbia,SPS,Социјалистичка партија Србије
+SRB,6628,Q7452863,Serbian Liberal Party,,Српска либерална странка
+SRB,3177,Q253586,Serbian Progressive Party,SNS,Српска напредна странка
+SRB,6787,Q15267567,Serbian Progressive Party (historical),,Српска напредна странка
+SRB,8880,Q18976059,Serbian People's Party,,Српска народна партија
+SRB,2175,Q334410,Serbian Radical Party,SRS,Српска радикална странка
+SRB,6793,Q1252106,Serbian Social Democratic Party,,Српска социјалдемократска партија
+SRB,5665,Q4155724,Dveri,,Српски покрет Двери
+SRB,2176,Q645681,Serbian Renewal Movement,,Српски покрет обнове
+SRB,3176,Q1264885,Party of Democratic Action of Sandžak,SDA/S,Stranka demokratske akcije Sandžaka
+SRB,5399,Q1278959,Party of Serbian Unity,,Странка српског јединства
+SRB,7648,Q20434676,Enough is Enough,,
+SRB,2181,Q3931958,United Regions of Serbia,,Уједињени региони Србије
+SRB,2203,Q1076922,Alliance of Vojvodina Hungarians,,Савез војвођанских Мађара
+SRB,2192,Q162866,For a European Serbia,,
+SRB,7175,Q15733561,Together for Serbia,,Заједно за Србију
+SRB,7873,Q2477383,Together for Šumadija,,Заједно за Шумадијy
+SRB,8365,Q24027940,Green Party (Serbia),,Зелена странка
+SRB,7876,Q1294528,Greens of Serbia,,Зелени Србије
+SYC,3847,Q206395,United Seychelles Party,,
+SYC,5956,Q48797479,Linyon Demokratik Seselwa,,Linyon Demokratik Seselwa
+SYC,5485,Q1266507,Seychelles Democratic Party,,
+SYC,4117,Q1253973,Seychelles National Party,,
+SLE,4045,Q385749,All People's Congress,,
+SLE,6514,Q6971931,National Council of Sierra Leone,,
+SLE,4048,Q6151267,People's Movement for Democratic Change,,
+SLE,4047,Q2033938,Sierra Leone People's Party,SLPP,
+SGP,4253,Q60518,Barisan Sosialis,,
+SGP,4213,Q1609748,"Justice Party, Singapore",,
+SGP,7165,Q20983884,Malay Union,,
+SGP,7166,Q958983,Malaysian Indian Congress,மஇகா/MIC,
+SGP,6893,Q5219964,Labour Front,,
+SGP,6894,Q20983873,Labour Party,,
+SGP,3279,Q1967746,National Solidarity Party,,
+SGP,6895,Q5255690,Democratic Party,,
+SGP,6896,Q6540805,Liberal Socialist Party,,
+SGP,6892,Q7248784,Progressive Party,,
+SGP,3277,Q371395,People's Action Party,PAP,
+SGP,4256,Q7165564,People's Front,,
+SGP,8620,Q20649050,People's Power Party,,
+SGP,4370,Q7170951,Pertubuhan Kebangsaan Melayu Singapura,,
+SGP,6898,Q1668154,United Malays National Organisation,UMNO/PEKEMBAR,
+SGP,5640,Q1375054,Reform Party,,
+SGP,5639,Q17053908,Singaporeans First Party,,
+SGP,5913,Q2289034,Singapore Democratic Alliance,,
+SGP,3561,Q2289041,Singapore Democratic Party,SDP,
+SGP,6897,Q7523074,Singapore People's Alliance,,
+SGP,4255,Q1320603,Singapore People's Party,,
+SGP,3651,Q5255766,Democratic Progressive Party,,
+SGP,4254,Q7889044,United People's Party,,
+SXM,8660,Q3040266,Democratic Party,,
+SXM,8659,Q47520052,United Democrats,,
+SXM,8662,Q18618866,United St. Maarten Party,,
+SXM,8661,Q18356643,United People's Party,,
+SVK,217,Q1552951,IDEA,,Aliancia nového občana
+SVK,707,Q3488035,Democratic Union,,
+SVK,6629,Q11774578,Democratic Union of Slovakia,DEÚS,Demokratická únia Slovenska
+SVK,6983,Q693985,Slovak People's Party,,Hlinkova slovenská ľudová strana –
+SVK,2133,Q112108692,Movement for Democracy,HZD,Republika
+SVK,340,Q1325836,Communist Party of Slovakia,,Komunistická strana Slovenska
+SVK,6980,Q1751122,Communist Party of Slovakia,,Komunistická strana Slovenska
+SVK,7360,Q61951420,Christian Union,,Kresťanská únia
+SVK,63,Q904070,Christian Democratic Movement,KDH,Kresťanskodemokratické hnutie
+SVK,560,Q828392,People's Party – Movement for a Democratic Slovakia,,Hnutie za demokratické Slovensko
+SVK,1725,Q605635,Liberal Party,,
+SVK,2283,Q12036214,Hungarian Christian Democratic Movement,MKDM,Magyar Kereszténydemokrata Mozgalom
+SVK,258,Q1068853,Most–Híd,,Most–Híd
+SVK,6686,Q12772632,New Majority,,
+SVK,665,Q3182266,Civic Conservative Party,OKS,Občianska konzervatívna strana
+SVK,2130,Q372043,Ordinary People,OĽaNO,Obyčajní ľudia a nezávislé osobnosti
+SVK,7361,Q48844389,Progressive Slovakia,PS,Progresívne Slovensko
+SVK,6984,Q2568847,Republican Party of Agricultural and Smallholder People,,
+SVK,4872,Q17115560,Slovak Conservative Party,SKS,Slovenská konzervatívna strana
+SVK,1386,Q220847,Freedom and Solidarity,SaS,Sloboda a solidarita
+SVK,137,Q3078673,Free Forum,,Slobodné fórum
+SVK,1617,Q837296,Slovak Democratic and Christian Union – Democratic Party,,Slovenská demokratická a kresťanská únia
+SVK,226,Q1611985,Slovak Democratic Coalition,SDK,Slovenská demokratická koalícia
+SVK,730,Q221480,Slovak National Party,,Slovenská národná strana
+SVK,4873,Q23025082,We Are Family,SR,Sme rodina
+SVK,311,Q821929,SMER – Social Democracy,SMER/SD,Smer – slovenská sociálna demokracia
+SVK,618,Q3777248,Social Democratic Alternative,,
+SVK,200,Q3111644,Social Democratic Party of Slovakia,,Sociálnodemokratická strana Slovenska
+SVK,205,Q3848925,Common Choice,,Spoločná voľba
+SVK,8177,Q51586047,SPOLU – občianska demokracia,SPOLU,SPOLU – občianska demokracia
+SVK,1077,Q974067,Coexistence,COEX/EGY,Együttélés-Spolužitie-Wspólnota-Soužití
+SVK,1242,Q3079712,Party of the Democratic Left,,Strana demokratickej ľavice
+SVK,2131,Q203880,Party of the Democratic Left,,
+SVK,349,Q904585,Party of the Hungarian Community,,Magyar Közösség Pártja
+SVK,2282,Q1858670,Freedom Party,,Strana slobody
+SVK,6981,Q1581594,Party of Slovak Revival,,Strana slovenskej obrody
+SVK,1569,Q259098,Green Party,,Strana zelených
+SVK,5,Q294592,Public Against Violence,,
+SVK,8394,Q64729826,For the People,ZĽ,Za ľudí
+SVK,230,Q169208,Union of the Workers of Slovakia,ZRS,Združenie robotníkov Slovenska
+SVN,1302,Q2274931,Active Slovenia,,
+SVN,467,Q1113577,Democratic Party of Pensioners of Slovenia,,Demokratična stranka upokojencev Slovenije
+SVN,1479,Q2408475,Democratic Party of Slovenia,,
+SVN,98,Q1261838,Civic List,,Državljanska lista
+SVN,8232,Q1277089,Democratic Party,,Демократска странка
+SVN,2273,Q1268112,League of Communists of Slovenia,,Zveza komunistov Slovenije
+SVN,6131,Q30668436,The Left,,Levica
+SVN,975,Q1258672,Liberal Democracy of Slovenia,,Liberalna demokracija Slovenije
+SVN,6132,Q53678274,List of Marjan Šarec,,Lista Marjana Šarca
+SVN,1773,Q678466,Positive Slovenia,,Pozitivna Slovenija
+SVN,1618,Q1258564,New Slovenia,,Nova Slovenija – Krščanski demokrati
+SVN,8230,Q172071,Liberation Front of the Slovene Nation,,
+SVN,3099,Q5314301,Slovenian Pirate Party,,Piratska stranka Slovenije
+SVN,740,Q1134702,Slovenia is Ours,,
+SVN,761,Q2396876,Slovenian Democratic Union,,
+SVN,472,Q526294,Slovenian Democratic Party,SDS,Slovenska demokratska stranka
+SVN,8231,Q1276547,Slovene People's Party,,Slovenska ljudska stranka
+SVN,764,Q1258654,Slovenian People's Party,,Slovenska ljudska stranka
+SVN,96,Q1049922,Slovenian National Party,SNS,Slovenska nacionalna stranka
+SVN,644,Q2395554,Slovene Christian Democrats,,
+SVN,1037,Q957547,Socialist Party of Slovenia,,
+SVN,1403,Q917211,Social Democrats,SD,Socialni demokrati
+SVN,881,Q1564169,Lipa,,
+SVN,3098,Q17118212,Modern Centre Party,,Stranka modernega centra
+SVN,1401,Q1590807,Youth Party – European Greens,,Stranka mladih – Zeleni Evrope
+SVN,3205,Q17056666,Verjamem,,
+SVN,474,Q147910,Zares,,Zares — socialno-liberalni
+SVN,3114,Q17061458,Party of Alenka Bratušek,,Stranka Alenke Bratušek
+SVN,4714,Q17100146,The Left,,Združena levica
+SVN,1494,Q1275990,Greens of Slovenia,,Andrej Čuš in Zeleni Slovenije
+SLB,5789,Q5255692,Democratic Party,,
+SLB,5737,Q5943774,Solomon Islands Liberal Party,,
+SLB,5938,Q7114938,"Ownership, Unity and Responsibility Party",,
+SLB,5282,Q7165458,People's Alliance Party,,
+SLB,5736,Q1076987,Solomon Islands Labour Party,,
+SLB,5937,Q7558649,Solomon Islands Social Credit Party,,
+SLB,5284,Q7558648,Solomon Islands United Party,,
+SOM,8445,Q339636,Somali Salvation Democratic Front,,
+SOM,6736,Q7559131,Somali African National Union,,الاتحاد الافريقي الوطني الصومالي
+SOM,5220,Q1458148,Somali Youth League,,Ururka Dhalinyarada Soomaaliyeed
+SOM,8443,Q946770,United Somali Congress,,
+SOM,5286,Q619530,Somali Revolutionary Socialist Party,SRSP/English,Xisbiga Hantiwadaagga Kacaanka Soomaaliyeed
+SOM,8444,Q2054264,Peace and Development Party,,Xisbiga Nabadda Iyo Horumarka
+SML,4109,Q521072,"Peace, Unity, and Development Party",,"Xisbiga Kulmiye Nabad, Midnimo iyo Horumarka"
+SML,4110,Q1239685,Justice and Welfare Party,UCID,Ururka Caddaalada iyo Daryeelka
+SML,7374,Q1458148,Somali Youth League,,Ururka Dhalinyarada Soomaaliyeed
+SML,4108,Q2005674,United Peoples' Democratic Party,,Ururka Dimuqraadiga Ummadda Bahawday
+ZAF,6186,Q268613,African Christian Democratic Party,ACDP,
+ZAF,1219,Q83162,African National Congress,ANC,African National Congress
+ZAF,5732,Q3366175,Afrikaner Party,,
+ZAF,8698,Q793572,Azanian People's Organisation,,
+ZAF,4546,Q1125988,Congress of the People,,
+ZAF,1609,Q776414,Conservative Party of South Africa,,
+ZAF,1038,Q761877,Democratic Alliance,DA,
+ZAF,4547,Q780158,Democratic Party,DP,
+ZAF,4548,Q15613585,Economic Freedom Fighters,EFF,
+ZAF,6291,Q925910,Herstigte Nasionale Party,HNP,
+ZAF,6187,Q256561,Independent Democrats,,
+ZAF,1630,Q654444,Inkatha Freedom Party,IFP,
+ZAF,5197,Q3136263,Labour Party,,Suid-Afrikaanse Arbeidersparty
+ZAF,8677,Q779783,Labour Party,,Arbeidersparty van Suid-Afrika
+ZAF,1289,Q740718,National Party,NP,Nasionale Party
+ZAF,6608,Q2782176,National Union,,
+ZAF,5731,Q1751732,New National Party,NNP,Nuwe Nasionale Party
+ZAF,5734,Q7011169,New Republic Party,,
+ZAF,1592,Q775460,Pan Africanist Congress of Azania,PAC,
+ZAF,5255,Q2096864,Progressive Federal Party,PFP,Progressiewe Federale Party
+ZAF,6149,Q2784503,Progressive Party,,
+ZAF,8448,Q7248781,Progressive Party,,
+ZAF,1368,Q305317,South African Communist Party,,
+ZAF,5251,Q1473242,South African Party,,
+ZAF,5253,Q2403816,Unionist Party,,Unionisteparty
+ZAF,5542,Q1788070,United Democratic Movement,,
+ZAF,5254,Q1812146,United Party,UP,
+ZAF,6041,Q510163,Freedom Front Plus,,
+SSD,5554,Q459960,Sudan People's Liberation Movement,,الحركة الشعبية لتحرير السودان
+ESP,2413,Q339186,Republican Action,,Acción Republicana
+ESP,8262,Q60774846,Agreement of Nationalist Unity,,Acuerdo de Unidad Nacionalista
+ESP,841,Q4893367,Agrupación Ruiz-Mateos,Ruiz/Mateos,Partido del Trabajo y Empleo-Agrupación Ruiz-Mateos
+ESP,8271,Q24054693,A la valenciana,,A la valenciana
+ESP,441,Q185088,People's Party,PP,Partido Popular
+ESP,1671,Q452571,Amaiur,,
+ESP,1011,Q885433,Galician Nationalist Bloc,,Bloque Nacionalista Galego
+ESP,8261,Q1519992,Canarian Nationalist Party,,Partido Nacionalista Canario
+ESP,8357,Q130761,Popular Unity Candidacy,CUP,Candidatura d'Unitat Popular
+ESP,1248,Q788345,Democratic and Social Centre,CDS,Centro Democratico y Social
+ESP,1564,Q1089640,Chunta Aragonesista,CHA,Chunta Aragonesista
+ESP,6783,Q28226410,Ciervists,,Ciervistas
+ESP,3217,Q1393123,Ciudadanos,Cs,Ciudadanos–Partido de la Ciudadanía
+ESP,5623,Q927193,Compromís,,
+ESP,81,Q1104327,Canarian Coalition,,Coalición Canaria
+ESP,984,Q11681518,Christian Democratic Team of the Spanish State,,Equipo Demócrata Cristiano del Estado Español
+ESP,8651,Q3306652,Galician Coalition,,Coalición Galega
+ESP,8814,Q3393021,People's Coalition,AP/UV/PDP/UL,Coalición Popular
+ESP,5853,Q8347293,Coalition for the Europe of the Peoples,,Coalición por la Europa de los Pueblos
+ESP,4598,Q1124888,Spanish Confederation of the Autonomous Right,,Confederación Española de Derechas Autónomas
+ESP,6779,Q5678936,Republican–Socialist Conjunction,CRS,Conjunción Republicano–Socialista
+ESP,6781,Q28155680,Maurist Party,,Partido Maurista
+ESP,4795,Q1129443,Democratic Convergence of Catalonia,CDC,Convergència Democràtica de Catalunya
+ESP,139,Q150398,Convergence and Union,CiU,Convergència i Unió
+ESP,4595,Q2752891,Liberal Republican Right,DLR,Derecha Liberal Republicana
+ESP,8031,Q21272208,En Comú Podem,ECP,En Comú Podem
+ESP,5873,Q21526202,En Marea,,En Marea
+ESP,8637,Q3320917,Verdes Equo,Equo,Verdes Equo
+ESP,8032,Q21523398,És el moment,,És el moment
+ESP,848,Q150068,Republican Left of Catalonia,ERC,Esquerra Republicana de Catalunya
+ESP,1643,Q2603148,Europe of the Peoples–Greens,,Europa de los Pueblos–Verdes
+ESP,5668,Q1029761,Euskal Herria Bildu,EH/Bildu,Euskal Herria Bildu
+ESP,1324,Q1125061,Eusko Alkartasuna,EA,Basque:
+ESP,1326,Q2531228,Euskadiko Ezkerra,EE,
+ESP,5778,Q1249339,Falange Española Tradicionalista y de las JONS,FET/JONS,Falange Española Tradicionalista y de las Juntas de Ofensiva Nacional Sindicalista
+ESP,8358,Q620781,Geroa Bai,GBAI,
+ESP,473,Q209546,Batasuna,,Batasuna
+ESP,1141,Q3298169,Iniciativa Internacionalista,,Iniciativa Internacionalista-La Solidaridad entre los Pueblos
+ESP,1260,Q149877,Initiative for Catalonia Greens,ICV,
+ESP,6776,Q532941,Dynastic Left,,Izquierda Dinástica
+ESP,6782,Q62011148,Liberal Left,,Izquierda Liberal
+ESP,4593,Q2351459,Republican Left,IR,Izquierda Republicana
+ESP,247,Q623740,United Left,,Izquierda Unida
+ESP,6777,Q28226392,Gamacists,,Gamacistas
+ESP,7011,Q429078,PSUC viu,,Partit Socialista Unificat de Catalunya viu
+ESP,4592,Q3052430,Regionalist League,,Lliga Regionalista de Catalunya
+ESP,2457,Q1124937,the Greens,,Confederación de los Verdes
+ESP,2455,Q3395554,The Ecologist Greens,,Los Verdes Ecologistas
+ESP,8395,Q68609827,Más País,,Más País
+ESP,611,Q1403103,Nafarroa Bai,,Nafarroa Bai
+ESP,4587,Q3178527,Autonomous Galician Republican Organization,,Organización Republicana Galega Autónoma
+ESP,4599,Q2701605,Spanish Agrarian Party,,
+ESP,3219,Q82558,Party Against Mistreatment to Animals,PACMA,
+ESP,946,Q2054574,Aragonese Party,PAR,Partido Aragonés
+ESP,2540,Q679189,Carlism,,
+ESP,8186,Q478811,Communist Party of Spain,PCE,Partido Comunista de España
+ESP,8185,Q2386352,Communist Party of the People of Spain,PCPE,Partido Comunista de los Pueblos de España
+ESP,4600,Q6064586,Party of the Democratic Centre (Spain),,Partido del Centro Democrático
+ESP,531,Q3133165,Workers' Party of Spain – Communist Unity,,Partido de los Trabajadores de España–Unidad Comunista
+ESP,2456,Q3328540,Party of Labour of Spain,,Partido del Trabajo de España
+ESP,206,Q634372,Democratic Popular Party,PDP,Partido Demócrata Popular
+ESP,5749,Q3323225,Radical Democratic Party,,Partido Demócrata Radical
+ESP,6778,Q16977228,Republican Union,UR,Partido de Unión Republicana
+ESP,366,Q3322686,Liberal Party,,Partido Liberal
+ESP,6774,Q3047700,Liberal-Conservative Party,PC,Partido Liberal-Conservador
+ESP,6780,Q28226403,Liberal Democratic Party,,Partido Liberal Demócrata
+ESP,6455,Q3178479,Liberal Party,PL,Partido Liberal
+ESP,5751,Q2054678,Moderate Party,,Partido Moderado
+ESP,1637,Q43093,Basque Nationalist Party,EAJ,Euzko Alderdi Jeltzalea (Basque)
+ESP,5750,Q635351,Progressive Party,,Partido Progresista
+ESP,7108,Q4891373,Reformist Party,,Partido Republicano Reformista
+ESP,4591,Q617220,Radical Socialist Republican Party,,Partido Republicano Radical Socialista
+ESP,5748,Q3125165,Democratic Federal Republican Party,PRDF,Partido Republicano Democrático Federal
+ESP,4590,Q2871932,Radical Republican Party,PRR,Partido Republicano Radical
+ESP,1338,Q138198,Spanish Socialist Workers' Party,PSOE,Partido Socialista Obrero Español
+ESP,6632,Q956240,Spanish Socialist Workers' Party of Andalusia,,Partido Socialista Obrero Español de Andalucía
+ESP,1687,Q3326660,Popular Socialist Party,,Partido Socialista Popular
+ESP,1497,Q1278980,Andalusian Party,PA,Partido Andalucista
+ESP,586,Q2055003,Socialists' Party of Catalonia,PSC,Partit dels Socialistes de Catalunya
+ESP,6027,Q25713876,Catalan European Democratic Party,PDeCAT,Partit Demòcrata Europeu Català
+ESP,7010,Q2630934,Unified Socialist Party of Catalonia,PSUC,Partit Socialista Unificat de Catalunya
+ESP,3203,Q16059622,Podemos,,
+ESP,4585,Q1508640,Renovación Española,RE,Renovación Española
+ESP,7656,Q24039754,Unidos Podemos,UP,Unidas Podemos
+ESP,4796,Q1628993,Democratic Union of Catalonia,UDC/unio/cat,Unió Democràtica de Catalunya
+ESP,6775,Q28226388,Conservative Union,,Unión Conservadora
+ESP,1271,Q549209,Union of the Democratic Centre,UCD,Unión de Centro Democrático
+ESP,1583,Q6157050,National Union,,Unión Nacional
+ESP,8121,Q2603441,Spanish Patriotic Union,,Unión Patriótica
+ESP,55,Q1144342,"Union, Progress and Democracy",UPyD,"Unión, Progreso y Democracia"
+ESP,1094,Q3087523,Valencian Union,UV,Unió Valenciana
+ESP,3218,Q15630787,Vox,,Vox
+LKA,8930,Q4728658,All Ceylon Makkal Congress,,
+LKA,5730,Q3269564,All Ceylon Tamil Congress,,Akila Ilankai Thamil Congress
+LKA,6868,Q4940058,"Bolshevik–Leninist Party of India, Ceylon and Burma",,
+LKA,4066,Q1814443,Tamil United Liberation Front,,தமிழர் ஐக்கிய விடுதலை முன்னணி
+LKA,6077,Q2724491,United People's Freedom Alliance,,එක්සත් ජනතා නිදහස් සන්ධානය
+LKA,1966,Q1321770,United National Party,,එක්සත් ජාතික පක්ෂය
+LKA,8070,Q3535341,Ceylon Workers' Congress,,இலங்கை தொழிலாளர் காங்கிரஸ்
+LKA,5447,Q3522458,Illankai Tamil Arasu Kachchi,ITAK,
+LKA,4067,Q1682545,Janatha Vimukthi Peramuna,,
+LKA,4068,Q3612384,Muslim National Unity Alliance,,தேசிய ஐக்கியக் கூட்டமைப்பு
+LKA,5414,Q2716578,Lanka Sama Samaja Party,,ලංකා සම සමාජ පක්ෂය
+LKA,6692,Q3522601,Mahajana Eksath Peramuna,,
+LKA,6078,Q13422309,People's Alliance (Sri Lanka),,පොදු ජන එක්සත් පෙරමුණ
+LKA,7135,Q5255851,Democratic United National Front,,ප්‍රජාතන්ත්‍රවාදී එක්සත් ජාතික පෙරමුණ
+LKA,4064,Q2496425,Sri Lanka Muslim Congress,,சிறீலங்கா முஸ்லீம் காங்கிரஸ்
+LKA,1967,Q1591064,Sri Lanka Freedom Party,,
+LKA,8499,Q28456145,Sri Lanka Podujana Peramuna,,
+LKA,6691,Q600703,Communist Party of Sri Lanka,,ශ්‍රී ලංකාවේ කොමියුනිස්ට් පක්ෂය
+LKA,5729,Q2303358,Tamil National Alliance,,
+LKA,7134,Q7933496,Viplavakari Lanka Sama Samaja Party,,Viplavakari Lanka Sama Samaja Party
+SDN,5495,Q459960,Sudan People's Liberation Movement,,الحركة الشعبية لتحرير السودان
+SDN,4754,Q5255850,Democratic Unionist Party,,الحزب الإتحادي الديموقراطي
+SDN,5494,Q1577744,Sudanese Socialist Union,,الاتحاد الاشتراكي السوداني
+SDN,5493,Q3774492,National Islamic Front,NIF,
+SDN,5496,Q1471945,National Congress Party,,المؤتمر الوطني
+SDN,6611,Q3278320,Sudan African National Union,,اتحاد الوطنى الافريقى السودان
+SDN,4756,Q4116138,National Umma Party,,حزب الأمة القومي
+SDN,4755,Q6540718,Liberal Party,,
+SDN,6346,Q22949247,People's Democratic Party,PDP,
+SUR,6079,Q2130965,A-Combination,,
+SUR,3728,Q1845964,Basic Party for Renewal and Democracy,,Basispartij voor Vernieuwing en Democratie
+SUR,7183,Q2011736,Brotherhood and Unity in Politics,,Broederschap en Eenheid in de Politiek
+SUR,7179,Q1111238,Democrats of the 21st Century,,Democraten van de 21e eeuw
+SUR,3729,Q3630425,Democratic Alternative '91,,Democratisch Alternatief '91
+SUR,8724,Q83799366,Reform and Renewal Movement,,
+SUR,5931,Q2075010,Party for National Unity and Solidarity,,
+SUR,8839,Q2871259,Megacombinatie,,
+SUR,3731,Q2420320,National Democratic Party,NDP,Nationale Democratische Partij
+SUR,5515,Q2564279,National Party of Suriname,NPS,Nationale Partij Suriname
+SUR,5799,Q2239194,New Front for Democracy and Development,,Nieuw Front voor Democratie en Ontwikkeling
+SUR,6849,Q2232487,Nationalist Republican Party,,Partij Nationalistische Republiek
+SUR,3725,Q1916205,Party for Democracy and Development through Unity,,Democratie en Ontwikkeling in Eenheid
+SUR,5504,Q195501,Pertjajah Luhur,,Pertjajah Luhur
+SUR,6076,Q2411463,Progressive Workers' and Farmers' Union,,Progressieve Arbeiders- en Landbouwersunie
+SUR,6853,Q2661095,Progressive Surinamese People's Party,,Progressieve Surinaamse Volkspartij
+SUR,7182,Q1817994,Surinamese Labour Party,SPA,Surinaamse Partij van de Arbeid
+SUR,7180,Q3634120,Meeting Point 2000,,
+SUR,5932,Q3633107,People's Alliance for Progress,,Volksalliantie Voor Vooruitgang
+SUR,5800,Q2188402,Progressive Reform Party,VHP,Vooruitstrevende Hervormingspartij
+SWZ,5558,Q6025175,Imbokodvo National Movement,,
+SWZ,5559,Q8349833,Ngwane National Liberatory Congress,,
+SWE,690,Q110843,Moderate Party,M,Moderata samlingspartiet
+SWE,199,Q110832,Centre Party,C,Centerpartiet
+SWE,1240,Q388981,Feminist Initiative,,Feministiskt initiativ
+SWE,1274,Q110857,Liberals,L,Liberalerna
+SWE,8876,Q7251368,Protectionist Party,,
+SWE,8718,Q4887122,Free-minded National Association,,Frisinnade Landsföreningen
+SWE,8716,Q1588993,Hats,,hattarna
+SWE,8719,Q4142672,Holstein Party,,
+SWE,8720,Q1623216,Hovpartiet,,Hovpartiet
+SWE,1093,Q1163309,June List,,Junilistan
+SWE,651,Q213654,Christian Democrats,KD,Kristdemokraterna
+SWE,4339,Q6487621,The Agrar Party,Lmp,
+SWE,4651,Q1594086,Free-minded National Association,,Frisinnade Landsföreningen
+SWE,456,Q213451,Green Party,MP,Miljöpartiet de gröna
+SWE,8715,Q1345901,Caps,,mössorna
+SWE,8172,Q10594830,National Progress Party,,Nationella progressiva partiet
+SWE,4790,Q3480145,National Party,,
+SWE,343,Q967278,New Democracy,,Ny Demokrati
+SWE,1485,Q3664326,Pirate Party,,
+SWE,487,Q105112,Swedish Social Democratic Party,S/SAP,Sveriges Socialdemokratiska Arbetareparti
+SWE,1959,Q2425638,Socialist Party,,Socialistiska partiet
+SWE,4053,Q4256329,Social Democratic Left Party of Sweden,,
+SWE,409,Q504069,Sweden Democrats,SD,
+SWE,2084,Q4574567,Communist Party of Sweden,,
+SWE,1960,Q4886664,Liberal Party of Sweden,,
+SWE,1530,Q1474673,Swedish Senior Citizen Interest Party,,SPI Välfärden
+SWE,830,Q110837,Left Party,V,Vänsterpartiet
+CHE,8184,Q255650,Alternative Left,,
+CHE,1311,Q672946,Freedom Party of Switzerland,,Freiheits-Partei der Schweiz
+CHE,1415,Q151768,Conservative Democratic Party of Switzerland,,Bürgerlich-Demokratische Partei Schweiz (BDP) ''([[German language|German]])''
+CHE,1122,Q667725,Christian Social Party,,
+CHE,631,Q667836,Federal Democratic Union of Switzerland,,Eidgenössisch-Demokratische Union
+CHE,1123,Q667718,Evangelical People's Party of Switzerland,,
+CHE,1231,Q202638,FDP.The Liberals,,
+CHE,360,Q13850128,Free Democratic Party of Switzerland,,Freisinnig-Demokratische Partei
+CHE,1006,Q659739,Green Party of Switzerland,GPS,
+CHE,1759,Q545900,Green Liberal Party of Switzerland,,
+CHE,1382,Q683672,Grütliverein,,Grütliverein
+CHE,1808,Q659461,Christian Democratic People's Party,CVP,Christlichdemokratische Volkspartei ''([[German language|German]])''
+CHE,8183,Q670486,Communist Party of Switzerland,KPS,Kommunistische Partei der Schweiz
+CHE,1194,Q550295,Ring of Independents,,
+CHE,1661,Q668101,Ticino League,,
+CHE,444,Q667785,Liberal Party of Switzerland,,
+CHE,8176,Q663580,Geneva Citizens' Movement,,
+CHE,1819,Q660046,Swiss Democrats,,
+CHE,669,Q661771,Swiss Party of Labour,,
+CHE,31,Q3366732,Autonomous Socialist Party,,
+CHE,121,Q362949,Swiss Progressive Organisations,,
+CHE,1646,Q2145393,Republican Movement,,Republikanische Bewegung
+CHE,4489,Q477228,"Party of Farmers, Traders and Independents",,
+CHE,308,Q385258,Swiss People's Party,SVP,Schweizerische Volkspartei ([[German language|German]])
+CHE,8653,Q286683,SolidaritéS,,solidaritéS
+CHE,29,Q303745,Social Democratic Party of Switzerland,PS/SP,
+SYR,7878,Q1637815,Syrian Communist Party (Bakdash),,الحزب الشيوعي السوري
+SYR,7880,Q1484270,Syrian Communist Party (Unified),,
+SYR,7877,Q767681,Syrian Social Nationalist Party,SSNP/English,
+SYR,7883,Q4268694,Democratic Socialist Unionist Party,,الحزب الوحدوي الاشتراكي الديمقراطي
+SYR,7294,Q1278453,Muslim Brotherhood in Syria,,
+SYR,7295,Q7916239,Arab Socialist Union,,حزب الاتحاد الاشتراكي العربي في سورية
+SYR,5217,Q1246360,National Progressive Front,,الجبهة الوطنية التقدمية
+SYR,8621,Q2484744,Popular Front for Change and Liberation,,الجبهة الشعبية للتحرير والتغيير
+SYR,8518,Q1890519,National Bloc,,الكتلة الوطنية
+SYR,7879,Q4268821,Socialist Unionist Party,,حزب الوحدويين الاشتراكيين
+SYR,7881,Q6979333,National Covenant Party,,حركة العهد الوطني
+SYR,7085,Q268280,Arab Socialist Movement,,حركة الاشتراكيين العرب
+SYR,7293,Q4783206,Arab Liberation Movement,,
+SYR,5216,Q16243030,Arab Socialist Ba’ath Party – Syria Region,,حزب البعث العربي الاشتراكي – قطر سوريا
+SYR,7884,Q4068393,Arabic Democratic Unionist Party,,حزب الاتحاد العربي الديمقراطي
+SYR,6036,Q6974800,National Party,,حزب الوطني
+SYR,6035,Q2377644,People's Party,,حزب الشعب
+SYR,8519,Q2509593,Al-Fatat,,
+TWN,1112,Q31113,Kuomintang,KMT,中國國民黨
+TWN,1596,Q903822,Democratic Progressive Party,,
+TWN,3665,Q1442482,People First Party,,親民黨
+TWN,5935,Q19825637,New Power Party,,時代力量
+TWN,6998,Q713302,Green Party Taiwan,,
+TWN,3664,Q706834,Taiwan Solidarity Union,,臺灣團結聯盟
+TWN,5936,Q718487,Non-Partisan Solidarity Union,,
+TWN,3666,Q2284361,New Party,,新黨
+TJK,6933,Q4693757,Agrarian Party,APT/English,Ҳизби аграрии Тоҷикистон
+TJK,4906,Q1045162,People's Democratic Party of Tajikistan,PDPT/English,Ҳизби халқии демократии Тоҷикистон
+TJK,4905,Q1780620,Communist Party of Tajik Soviet Socialist Republic,CPT/English,Ҳизби коммунистии Тоҷикистон
+TJK,5697,Q1674162,Islamic Renaissance Party of Tajikistan,IRP/or/IRPT,Ҳизби наҳзати исломии Тоҷикистон
+TJK,8570,Q25339902,Party of People's Unity,,Ҳизби иттиҳоди мардумии Тоҷикистон
+TJK,8485,Q3218145,Communist Party of Uzbek Soviet Socialist Republic,,Коммунистическая партия Узбекистана
+TZA,8676,Q388064,Afro-Shirazi Party,,Chama cha Afro-Shirazi
+TZA,5170,Q18161932,Alliance for Change and Transparency,ACT,
+TZA,2344,Q508898,Chadema,CHADEMA,
+TZA,2328,Q652091,Party of the Revolution,CCM,Chama cha Mapinduzi
+TZA,2345,Q1094460,Civic United Front,CUF,
+TZA,3276,Q6971840,National Convention for Construction and Reform – Mageuzi,NCCR/M,
+TZA,5788,Q2143929,Tanganyika African National Union,,
+TZA,3553,Q3357886,Tanzania Labour Party,TLP,
+TZA,6075,Q3357902,United Democratic Party,UDP,
+THA,4288,Q4921004,National Development Party,,พรรคชาติพัฒนา
+THA,6996,Q4924582,Chartthaipattana Party,,พรรคชาติไทยพัฒนา
+THA,4296,Q13017204,Progressive Party,,พรรคก้าวหน้า
+THA,5866,Q1127720,Khana Ratsadon,,คณะราษฎร
+THA,4289,Q1127756,New Aspiration Party,,พรรคความหวังใหม่
+THA,4286,Q16304789,Mass Party,,พรรคมวลชน
+THA,4290,Q6581404,New Force Party,,พรรคพลังใหม่
+THA,4310,Q1127750,Palang Dharma Party,,พรรคพลังธรรม
+THA,7915,Q50549434,Future Forward Party,,พรรคอนาคตใหม่
+THA,2373,Q1067749,Thai Nation Party,,พรรคชาติไทย
+THA,4115,Q1127730,Social Action Party,,พรรคกิจสังคม
+THA,7894,Q4389847,Mahachon Party,,พรรคมหาชน
+THA,2375,Q1889631,Neutral Democratic Party,,พรรคมัชฌิมาธิปไตย
+THA,2376,Q112051,People's Power Party,,พรรคพลังประชาชน
+THA,6919,Q55077745,Palang Pracharath Party,,พรรคพลังประชารัฐ
+THA,5398,Q1142913,Pheu Thai Party,,พรรคเพื่อไทย
+THA,6423,Q855111,Bhumjaithai Party,,พรรคภูมิใจไทย
+THA,4303,Q2408592,Thai Citizens' Party,,พรรคประชากรไทย
+THA,2327,Q1186248,Democrat Party,,พรรคประชาธิปัตย์
+THA,8512,Q6386067,Seri Manangkhasila Party,,พรรคเสรีมนังคศิลา
+THA,2377,Q3268090,Puea Pandin Party,,พรรคเพื่อแผ่นดิน
+THA,2378,Q3268292,Pracharaj Party,,พรรคประชาราช
+THA,6997,Q6581405,Rak Thailand Party,,พรรครักประเทศไทย
+THA,2374,Q1000840,Chart Pattana Party,,พรรคชาติพัฒนา
+THA,4304,Q13017228,United Thai People's Party,,พรรคสหประชาไทย
+THA,4306,Q6317114,Justice Unity Party,,พรรคสามัคคีธรรม
+THA,4299,Q7551711,Socialist Party of Thailand,,พรรคสังคมนิยมแห่งประเทศไทย
+THA,8513,Q708957,Free Thai Movement,,เสรีไทย
+THA,5397,Q1542181,Thai Rak Thai Party,,พรรคไทยรักไทย
+THA,4311,Q6581396,Social Justice Party (Thailand),,พรรคธรรมสังคม
+TLS,6148,Q744263,Timorese Social Democratic Association,,Associação Social-Democrata Timorense
+TLS,5625,Q935996,Revolutionary Front for an Independent East Timor,Fretilin/FRETILIN,Frente Revolucionária de Timor-Leste Independente
+TLS,7887,Q668067,Frenti-Mudança,Frenti/Mudança,Frente de Reconstrução Nacional de Timor-Leste – Mudança
+TLS,5675,Q1571660,Kmanek Haburas Unidade Nasional Timor Oan,KHUNTO,Kmanek Haburas Unidade Nasional Timor Oan
+TLS,5626,Q523216,Democratic Party,,Partido Democrático
+TLS,5672,Q626170,Timorese Nationalist Party,PNT,Partido Nacionalista Timorense
+TLS,5671,Q930331,Social Democratic Party,,Partido Social Democrata
+TLS,5674,Q673862,National Unity Party,,
+TLS,7658,Q25379578,People's Liberation Party,PLP,Partidu Libertasaun Popular
+TLS,7886,Q948124,Timorese Democratic Union,,União Democrática Timorense
+TGO,8071,Q4732444,Alliance of Democrats for Integral Development,,
+TGO,5767,Q2838206,National Alliance for Change,ANC,Alliance Nationale pour le Changement
+TGO,7185,Q22080518,Rainbow Alliance,,
+TGO,4132,Q16540801,Let's Save Togo Collective,CST,
+TGO,4133,Q4677086,Action Committee for Renewal,,
+TGO,4764,Q2985355,Party of Togolese Unity,,Parti de l'unité togolaise
+TGO,8752,Q2996304,Democratic Convention of African Peoples,,
+TGO,8530,Q2996378,Patriotic Pan-African Convergence,CPP,
+TGO,8529,Q5168034,Coordination of New Forces,,
+TGO,7660,Q22080481,New Togolese Commitment,,
+TGO,8764,Q7551625,Socialist Pact for Renewal,,
+TGO,7661,Q5255671,Democratic Pan-African Party,,
+TGO,4763,Q2800838,Togolese Party of Progress,,
+TGO,4131,Q1514253,Rally of the Togolese People,,Rassemblement du Peuple Togolais
+TGO,6409,Q21281624,Togolese People's Movement,,
+TGO,4762,Q22115575,Democratic Union of the Togolese People,,
+TGO,4761,Q22115648,Union of Chiefs and Peoples of the North,,
+TGO,4130,Q2151805,Union of Forces for Change,UFC,Union des Forces du Changement
+TGO,4129,Q22080618,Union for the Republic,UNIR,Union pour la République
+TGO,6613,Q23777567,Togolese Union for Democracy,,
+TON,5334,Q1982691,Human Rights and Democracy Movement,,
+TON,6934,Q3366423,Democratic Party of the Friendly Islands,DPFI,Paati Temokalati ʻa e ʻOtu Motu ʻAngaʻofa
+TON,5333,Q2746576,People's Democratic Party,,
+PMR,7498,Q1967163,Obnovlenie,,Республиканская партия «Обновление»
+PMR,7499,Q7314380,Republic,,"Republica, Република"
+PMR,7497,Q7893742,Unity,,"Unitate, Унитате"
+TTO,6858,Q5002635,Butler Party,,
+TTO,4285,Q777399,Congress of the People,,
+TTO,5698,Q5255537,Democratic Action Congress,,
+TTO,5386,Q5255633,Democratic Labour Party,DLP,
+TTO,4284,Q6970302,National Alliance for Reconstruction,,
+TTO,8675,Q6973884,National Joint Action Committee,NJAC,
+TTO,8831,Q7101886,Organisation for National Reconstruction,,
+TTO,4283,Q3326740,People's National Movement,PNM,
+TTO,5388,Q7165659,People's Partnership,PP,
+TTO,4280,Q7811540,Tobago Organisation of the People,,
+TTO,5387,Q7888203,United Labour Front,,
+TTO,4281,Q1024804,United National Congress,UNC,
+TUN,8622,Q382146,Afek Tounes,,آفاق تونس
+TUN,7918,Q18205783,Free Destourian Party,,
+TUN,7917,Q17197994,Democratic Current,,التيار الديمقراطي
+TUN,4532,Q1460650,Congress for the Republic,El/Mottamar,
+TUN,4534,Q1969819,Current of Love,,
+TUN,5586,Q3088551,Popular Front,ej/Jabha,
+TUN,6074,Q1371752,Democratic Forum for Labour and Liberties,Ettakatol,
+TUN,7082,Q1371734,Ettajdid Movement,,
+TUN,5326,Q852230,Movement of Socialist Democrats,MDS,
+TUN,7919,Q3326655,Movement of the People,,
+TUN,5832,Q692022,Ennahda Movement,,حركة النهضة
+TUN,4530,Q929717,Call for Tunisia,,حركة نداء تونس
+TUN,8446,Q1507590,Neo Destour,,
+TUN,6222,Q1633424,Party of People's Unity,PUP,
+TUN,8447,Q587187,Destour,Destour,
+TUN,5781,Q1232615,Socialist Destourian Party,,
+TUN,7083,Q1340886,Social Liberal Party,PSL,
+TUN,4533,Q1186170,Progressive Democratic Party,PDP,
+TUN,7916,Q67263863,Heart of Tunisia,,قلب تونس
+TUN,4757,Q1137248,Constitutional Democratic Rally,RCD,التجمع الدستوري الديمقراطي
+TUN,7920,Q64245468,Tahya Tounes,,
+TUN,7084,Q1633434,Unionist Democratic Union,UDU,
+TUN,6073,Q1328991,Free Patriotic Union,,الاتحاد الوطني الحرّ
+TUR,4373,Q348125,Justice Party,,Adalet Partisi
+TUR,306,Q19077,Justice and Development Party,AK/PARTİ,Adalet ve Kalkınma Partisi
+TUR,1190,Q488511,Motherland Party,,Anavatan Partisi
+TUR,2503,Q809719,Peace and Democracy Party,,Barış ve Demokrasi Partisi
+TUR,1330,Q1021872,Great Unity Party,,Büyük Birlik Partisi
+TUR,4378,Q6089601,Republican Villagers Nation Party,,Cumhuriyetçi Köylü Millet Partisi
+TUR,4377,Q6061121,Republican Nation Party,,
+TUR,1060,Q19079,Republican People's Party,CHP,Cumhuriyet Halk Partisi
+TUR,1355,Q645397,Democratic People's Party,,
+TUR,4376,Q5255699,Democratic Party,,Demokratik Parti
+TUR,1740,Q942515,Democratic Left Party,,Demokratik Sol Parti
+TUR,1606,Q1138606,Democratic Society Party,DTP,
+TUR,899,Q2067217,Democratic Party,DP,Demokrat Parti
+TUR,4758,Q1186034,Democrat Party,,Demokrat Parti
+TUR,398,Q6084498,Democrat Turkey Party,,Demokrat Türkiye Partisi
+TUR,351,Q6061183,True Path Party,DYP,Doğru Yol Partisi
+TUR,1463,Q1399162,Virtue Party,,Fazilet Partisi
+TUR,159,Q1502746,Young Party,GENÇPARTİ,Genç Parti
+TUR,4371,Q250556,Republican Reliance Party,,
+TUR,1423,Q917074,People's Party,,
+TUR,6515,Q3674950,People's Labor Party,,Halkın Emek Partisi
+TUR,2472,Q1571253,People's Democracy Party,,
+TUR,6042,Q15123187,Peoples' Democratic Party,HDP,Halkların Demokratik Partisi
+TUR,4374,Q6541911,Liberty Party,,
+TUR,8521,Q1559352,Committee of Union and Progress,İ/T/or/İTC/or/İTF,İttihad ve Terakki Cemiyeti
+TUR,6236,Q42313794,İYİ Party,İYİ/Parti,İYİ Parti
+TUR,815,Q1515927,National Salvation Party,,Millî Selamet Partisi
+TUR,178,Q428886,Nationalist Democracy Party,,
+TUR,1610,Q251077,Nationalist Movement Party,MHP,Milliyetçi Hareket Partisi
+TUR,1067,Q920212,Welfare Party,,Refah Partisi
+TUR,572,Q1637009,Felicity Party,SAADET,Saadet Partisi
+TUR,1253,Q929507,Social Democratic Populist Party,,Sosyaldemokrat Halkçı Parti
+TUR,4372,Q785156,Unity Party,,Türkiye Birlik Partisi
+TUR,7926,Q12812587,New Turkey Party (1961),,
+TUR,2471,Q3366331,New Turkey Party,NTP,Yeni Türkiye Partisi
+TKM,5287,Q2368985,Communist Party of Turkmen Soviet Socialist Republic,,Türkmenistanyñ Kommunistik Partiýasy
+TKM,5890,Q13628510,Party of Industrialists and Entrepreneurs,TSTP/Turkmen,Türkmenistanyň Senagatçylar we Telekeçiler partiýasy
+TKM,5202,Q1152752,Democratic Party of Turkmenistan,TDP/Turkmen,Türkmenistanyň Demokratik Partiýasy
+TKM,5889,Q55664266,Women's Union of Turkmenistan,TZB,Türkmenistanyň zenanlar birleşigi
+TCA,4120,Q7165523,People's Democratic Movement,PDM,
+TCA,4121,Q7248774,Progressive National Party,PNP,
+UGA,8929,Q3366253,Conservative Party,CP,
+UGA,4525,Q4157645,Democratic Party,,Chama cha Kidemokrasia
+UGA,5389,Q5473101,Forum for Democratic Change,,Jukwaa la Mabadiliko ya Kidemokrasia
+UGA,4781,Q257787,Kabaka Yekka,,
+UGA,4523,Q382674,National Resistance Movement,NRM,Harakati za Upinzani za Kitaifa
+UGA,6614,Q7877614,Uganda National Congress,,
+UGA,5841,Q2738248,Uganda National Liberation Front,,
+UGA,4524,Q2187095,Uganda People's Congress,,Congress ya Watu wa Uganda
+UKR,2215,Q12076620,Agrarian Party of Ukraine,,Аграрна партія України
+UKR,2230,Q884932,Lytvyn Bloc,,Блок Литвина
+UKR,2231,Q788180,Our Ukraine–People's Self-Defense Bloc,,
+UKR,2228,Q383371,Yulia Tymoshenko Bloc,,Блок Юлії Тимошенко
+UKR,2222,Q4157651,Democratic Party of Ukraine,,Демократична партія України
+UKR,4778,Q4349891,European Solidarity,,Європейська солідарність
+UKR,7923,Q63869413,Holos,,Голос
+UKR,3554,Q1984877,Hromada,,Громада
+UKR,4780,Q4147532,Civil Position,,Громадянська позиція
+UKR,6986,Q12116762,Komsomol of Ukraine,LCSYU,Ле́нінська Комуністи́чна Спі́лка Мо́лоді Украї́ни (ЛКСМУ)
+UKR,8251,Q19600746,Communist Party of Workers and Peasants,,
+UKR,2220,Q1122797,Communist Party of Ukraine,KPU,Комуністична партія України
+UKR,6985,Q2263934,Communist Party of Ukrainian Soviet Socialist Republic,КПУ,Комуністична Партія України
+UKR,8250,Q5154462,Communist Party of Ukraine (renewed),,
+UKR,8253,Q2982576,Liberal Party of Ukraine,,Ліберальна партія України
+UKR,3158,Q4260831,Liberal Democratic Party of Ukraine,,Ліберально-демократична партія України
+UKR,2206,Q2636074,People's Democratic Party,,Народно-демократична партія
+UKR,2207,Q2351483,People's Movement of Ukraine,НРУ,Народний Рух України
+UKR,4773,Q18015490,People's Front,,Народний фронт
+UKR,4779,Q18121206,Opposition Bloc,,Опозиційний блок
+UKR,7922,Q4127627,Opposition Platform — For Life,OPZZh/or/OPFL,Опозицiйна платформа — За життя
+UKR,8366,Q2299546,Our Ukraine,,Наша Україна
+UKR,2226,Q2415479,Party of Greens of Ukraine,,Партія Зелених України
+UKR,2232,Q12139017,Party of Democratic Revival of Ukraine,,
+UKR,6072,Q7141088,Party of Labor,,Партія праці
+UKR,8566,Q2994303,Party of Industrialists and Entrepreneurs of Ukraine,,Партія промисловців і підприємців України
+UKR,5548,Q1629755,Reforms and Order Party,,Partiya Reformy i Poriadok
+UKR,2234,Q4266,Party of Regions,,Партія регіонів
+UKR,4775,Q15361249,Right Sector,,Пра́вий се́ктор
+UKR,2208,Q947126,Progressive Socialist Party of Ukraine,ПСПУ,
+UKR,4774,Q2355317,Radical Party of Oleh Liashko,,Радикальна Партія Олега Ляшка
+UKR,4776,Q12139013,Samopomich,,Самопоміч
+UKR,7921,Q52292915,Servant of the People,,Слуга народу
+UKR,8270,Q4430186,Social Democratic Party of Ukraine,SDPU,Соцiал-демократична партія України
+UKR,2210,Q1499300,Social Democratic Party of Ukraine (united),SDPU/o,Соцiал-демократична партія України (об`єднана)
+UKR,2211,Q922724,Socialist Party of Ukraine,СПУ,Соціалістична партія України
+UKR,3178,Q2065158,Strong Ukraine,,Сильна Україна
+UKR,2212,Q12163836,Ukrainian Conservative Republican Party,,
+UKR,8926,Q515003,Ukrainian People's Party,,Українська Народна Партія
+UKR,2213,Q2034609,Ukrainian National Assembly – Ukrainian National Self Defence,,Українська Національна Асамблея
+UKR,5825,Q290441,Ukrainian Democratic Alliance for Reform,,"Український демократичний
+ альянс за реформи Віталія Кличка"
+UKR,4772,Q18346923,Zastup,,"Всеукраїнський аграрний об'єднання ""заступ"""
+UKR,3267,Q4396,"All-Ukrainian Union ""Svoboda""",ВО/Свобода,Всеукраїнське об'єднання «Свобода»
+UKR,3266,Q45376,Batkivshchyna,,Всеукраїнське об'єднання «Батьківщина»
+UKR,8252,Q1984161,Party of Free Democrats,,
+UKR,2224,Q974724,For United Ukraine,,За Єдину Україну!
+GBR,1477,Q244927,Alliance Party of Northern Ireland,APNI,
+GBR,3198,Q16828185,An Independence from Europe,,
+GBR,8758,Q1817613,Progressive Unionist Party,PUP,
+GBR,7364,Q104721252,Reform UK,,
+GBR,855,Q161269,British National Party,,
+GBR,7365,Q61751194,Change UK,,
+GBR,116,Q592068,Communist Party of Great Britain,,Communist Party of Great Britain
+GBR,1567,Q9626,Conservative Party,Con,
+GBR,6374,Q2633397,Peelite,,Peelites
+GBR,4557,Q17986644,Constitutionalist,,
+GBR,4885,Q211931,Co-operative Party,,
+GBR,335,Q215519,Democratic Unionist Party,DUP,Democratic Unionist Party
+GBR,1675,Q2479228,English Democrats,,
+GBR,8240,Q1096979,Green Party in Northern Ireland,,
+GBR,1794,Q9669,Green Party of England and Wales,GPEW,
+GBR,3680,Q476840,Home Rule League,,
+GBR,8654,Q1297754,Independent Community and Health Concern,,
+GBR,234,Q1507913,Independent Labour Party,ILP,
+GBR,1516,Q9630,Labour Party,Lab,Labour Party
+GBR,1388,Q9624,Liberal Democrats,Lib/Dems,Liberal Democrats
+GBR,540,Q622441,Liberal Party,Lib,
+GBR,2120,Q1754707,Liberal Unionist Party,LibU,
+GBR,2121,Q6972256,National Democratic and Labour Party,,
+GBR,1140,Q158093,National Front,,
+GBR,1623,Q6979788,Nationalist Party,Na,
+GBR,2122,Q2184291,National Labour Organisation,NLO,
+GBR,141,Q1354368,National Liberal Party,,
+GBR,2123,Q6974098,National Liberal Party,,
+GBR,1965,Q16958521,No2EU,,
+GBR,8757,Q7058511,Northern Ireland Labour Party,NILP,
+GBR,8272,Q7058538,Northern Ireland Women's Coalition,,
+GBR,8360,Q1860218,Workers' Party of Ireland,WP,Páirtí na nOibrithe
+GBR,1002,Q10691,Plaid Cymru,,Plaid Cymru
+GBR,164,Q7246586,Pro-Euro Conservative Party,,
+GBR,825,Q278315,Referendum Party,,
+GBR,3681,Q3777944,Repeal Association,,
+GBR,1082,Q287031,Respect Party,Respect,
+GBR,6687,Q1256956,Scottish Green Party,,
+GBR,986,Q10658,Scottish National Party,SNP,
+GBR,963,Q76382,Sinn Féin,SF,Sinn Féin
+GBR,762,Q175443,Social Democratic and Labour Party,SDLP,Páirtí Sóisialta Daonlathach an Lucht Oibre
+GBR,957,Q40052,Social Democratic Party,SDP,Social Democratic Party
+GBR,1277,Q3491460,Socialist Labour Party,,
+GBR,8732,Q499956,Tories,,Tories
+GBR,8263,Q985706,UK Unionist Party,,
+GBR,1366,Q841045,Ulster Unionist Party,UUP,
+GBR,601,Q10647,UK Independence Party,UKIP,United Kingdom Independence Party
+GBR,1262,Q7893620,United Ulster Unionist Council,UUUC,
+GBR,6221,Q108700,Whigs,,Whigs
+USA,2430,Q1541747,National Republican Party,,National Republican Party
+USA,2438,Q465099,American Independent Party,,American Independent Party
+USA,4505,Q4744300,American Labor Party,,
+USA,4517,Q574557,Anti-Administration Party,,
+USA,2293,Q574701,Anti-Masonic Party,,
+USA,3687,Q4774232,Anti-Monopoly Party,,
+USA,2434,Q1128268,Constitutional Union Party,,
+USA,432,Q29552,Democratic Party,D,Democratic Party
+USA,4538,Q42186,Democratic-Republican Party,,Democratic-Republican Party
+USA,2435,Q3066954,Farmer–Labor Party,,
+USA,5727,Q42189,Federalist Party,,Federalist Party
+USA,2436,Q1346993,Free Soil Party,,
+USA,2290,Q475261,Greenback Party,,Greenback Party
+USA,5728,Q1040924,Jacksonian Democracy,,
+USA,2431,Q550678,Know Nothing,,American Party
+USA,4504,Q6540796,Liberal Republican Party,,
+USA,2291,Q558334,Libertarian Party,LP,Libertarian Party
+USA,2437,Q4346026,Liberty Party,,
+USA,8879,Q80719,National Union Party,,National Union Party
+USA,8633,Q3440208,Nullifier Party,,
+USA,8635,Q7098629,Opposition Party,,
+USA,2395,Q337794,People's Party,,
+USA,2001,Q1364562,Progressive Party,,
+USA,2002,Q1638786,Progressive Party,,
+USA,2425,Q1363538,"Progressive Party (United States, 1912)",,
+USA,2426,Q515856,Prohibition Party,,
+USA,4433,Q2134572,Readjuster Party,,
+USA,3557,Q1893430,Reform Party of the United States of America,,
+USA,809,Q29468,Republican Party,GOP/Grand/Old/Party,Republican Party
+USA,2124,Q2982544,Socialist Labor Party of America,,Socialist Labor Party of America
+USA,2427,Q1353232,Socialist Party of America,,Socialist Party of America
+USA,1089,Q1231756,States' Rights Democratic Party,,
+USA,8631,Q7882904,Unconditional Union Party,,
+USA,8630,Q7886825,Unionist Party,,
+USA,8914,Q4345969,Union Party,,
+USA,2005,Q42183,Whig Party,,Whig Party
+USA,8877,Q8035000,Workingmen's Party of the United States,,
+URY,8123,Q63495952,Open Cabildo,,Cabildo Abierto
+URY,1658,Q1066799,Broad Front,,Frente Amplio
+URY,3671,Q1851370,New Space,,Nuevo Espacio
+URY,1419,Q1430823,Colorado Party,,Partido Colorado
+URY,4492,Q1535996,Communist Party of Uruguay,,
+URY,4493,Q3140829,Christian Democratic Party of Uruguay,,Partido Demócrata Cristiano del Uruguay
+URY,518,Q1624802,Independent Party,,Partido Independiente
+URY,118,Q1549793,National Party,,Partido Nacional
+URY,6866,Q406644,Independent National Party,,
+URY,4490,Q1282824,Socialist Party of Uruguay,,Partido Socialista del Uruguay
+URY,8743,Q18417007,Popular Unity (Uruguay),UP,Unidad Popular
+URY,353,Q1581223,Civic Union,,Unión Cívica
+UZB,5101,Q6317086,Justice Social Democratic Party,ASDP,Adolat Sotsial Demokratik Partiyasi
+UZB,6238,Q7893745,Unity,,Birlik partiyasi
+UZB,8567,Q4100482,Communist Party of Bukhara,,حزب کمونیست بخارا
+UZB,8487,Q79854,Communist Party of the Soviet Union,CPSU/KPSS,
+UZB,7320,Q86674609,Ecological Movement of Uzbekistan,EPU,O`zbekiston ekologik partiyasi
+UZB,6185,Q1981737,Liberty Democratic Party,EDP,
+UZB,5831,Q2945416,Self-Sacrifice National Democratic Party,FMDP,Fidokorlar milliy demokratik partiyasi
+UZB,8486,Q3218145,Communist Party of Uzbek Soviet Socialist Republic,,Коммунистическая партия Узбекистана
+UZB,5100,Q1029663,People's Democratic Party of Uzbekistan,XDP,O'zbekistan Xalq Demokratik Partiyasi
+UZB,5099,Q1146334,Uzbekistan Liberal Democratic Party,UzLiDeP,Oʻzbekiston Liberal Demokratik Partiyasi
+UZB,5102,Q7076484,Uzbekistan National Revival Democratic Party,UzMTDP,Oʻzbekiston “Milliy Tiklanish” Demokratik Partiyasi
+VUT,5546,Q3366161,Land and Justice Party,,Graon mo Jastis Pati
+VUT,5543,Q1987660,Green Confederation,Ol/Grin,Vanuatu Grin Konfederesen
+VUT,8623,Q24661025,Iauko Group,IG,Iauko Grup
+VUT,5339,Q1150838,Melanesian Progressive Party,,
+VUT,6045,Q7885221,Nagriamel,,
+VUT,5545,Q94249083,Reunification Movement for Change,RMC,
+VUT,5338,Q1096175,Vanuatu Republican Party,,
+VUT,5888,Q31314,People's Progress Party,,
+VUT,5336,Q31360,Union of Moderate Parties,,Union des Partis Moderés
+VUT,5335,Q31373,Vanua'aku Pati,VP,Vanua'aku Pati
+VUT,5544,Q23023640,Vanuatu National Development Party,,
+VUT,5337,Q1096198,National United Party,NUP,
+VEN,7982,Q5439493,Fearless People's Alliance,,Alianza Bravo Pueblo
+VEN,7979,Q5713120,Progressive Advance,,Avanzada Progresista
+VEN,4759,Q1114939,COPEI,,Comité de Organización Política Electoral Independiente
+VEN,4804,Q388554,Convergence,,Convergencia Nacional
+VEN,4809,Q5792508,Nationalist Civic Crusade,,
+VEN,4803,Q506107,Radical Cause,,La Causa Radical
+VEN,5095,Q1629486,Democratic Unity Roundtable,,Mesa de la Unidad Democrática
+VEN,646,Q429548,Movement for Socialism,,Movimiento al Socialismo
+VEN,4818,Q7318809,Revolutionary Left Movement,,Movimiento  de  Izquierda  Revolucionaria
+VEN,4805,Q344913,People's Electoral Movement,,Movimiento Electoral del Pueblo
+VEN,1754,Q1336488,Fifth Republic Movement,,Movimiento Quinta República
+VEN,1483,Q847914,Communist Party of Venezuela,PCV,Partido Comunista de Venezuela
+VEN,8310,Q6063977,Conservative Party,,
+VEN,6301,Q3727795,Venezuelan Democratic Party,,Partido Democrático Venezolano
+VEN,8308,Q16150762,Great Liberal Party of Venezuela,,Gran Partido Liberal de Venezuela
+VEN,5094,Q197864,United Socialist Party of Venezuela,PSUV,Partido Socialista Unido de Venezuela
+VEN,1356,Q60668,Fatherland for All,,Patria para Todos
+VEN,413,Q2528660,For Social Democracy,,Por la Democracia Social
+VEN,361,Q8794,Justice First,,Primero Justicia
+VEN,4802,Q3179082,Project Venezuela,,Project Venezuela
+VEN,4760,Q2919168,Democratic Republican Union,,Unión Republicana Democrática
+VEN,849,Q1641259,A New Era,,Un Nuevo Tiempo
+VEN,7980,Q16645762,Vente Venezuela,,Vente Venezuela
+VEN,7976,Q7229748,Popular Will,VP,Voluntad Popular
+VNM,4898,Q427325,Communist Party of Vietnam,,Đảng Cộng sản Việt Nam
+VNM,6901,Q210363,Democratic Party of Vietnam,,Đảng Dân chủ Việt Nam
+VNM,6900,Q1628865,Vietnamese Fatherland Front,,Mặt Trận Tổ Quốc Việt Nam
+VNM,6902,Q1365892,Nationalist Party of Vietnam,,Việt Nam Quốc Dân Đảng
+VNM,6903,Q4919986,Socialist Party of Vietnam,,
+VNR,8516,Q4919971,Personalist Labor Revolutionary Party,,Cần lao Nhân vị Cách Mạng Ðảng
+VNR,8515,Q174423,National Front for the Liberation of South Vietnam,,
+VNR,6057,Q6979793,Nationalist Party of Greater Vietnam,,
+VNR,8514,Q15407933,National Social Democratic Front,,Mặt trận Quốc gia Dân chủ Xã hội
+VNR,6905,Q1365892,Nationalist Party of Vietnam,,Việt Nam Quốc Dân Đảng
+ESH,5578,Q240425,Polisario Front,Polisario,جبهة البوليزاريو
+YEM,4164,Q1149512,Yemeni Socialist Party,,الحزب الاشتراكي اليمني
+YEM,4163,Q285388,Al-Islah,,التجمع اليمني للإصلاح
+YEM,4162,Q1460677,General People's Congress,,المؤتمر الشعبي العام
+YEM,4328,Q4118233,Nasserist Unionist People's Organisation,,التنظيم الوحدوي الشعبي الناصري
+YEM,8928,Q4783243,Arab Socialist Baath Party – Yemen Region,,حزب البعث العربي الاشتراكي - قطر اليمن
+YMD,5218,Q1149512,Yemeni Socialist Party,,الحزب الاشتراكي اليمني
+YMD,5720,Q6974114,National Liberation Front,,
+ZMB,7291,Q23777610,Central Africa Party,,
+ZMB,7288,Q24235902,Federal Party,,
+ZMB,2332,Q625541,Forum for Democracy and Development,,
+ZMB,3685,Q183176,Heritage Party,NHP,
+ZMB,2333,Q1951163,Movement for Multi-Party Democracy,MMD,Movement for Multi-Party Democracy
+ZMB,4123,Q1966993,National Citizens' Coalition,,
+ZMB,4126,Q1690831,National Party,,
+ZMB,2302,Q2058159,Patriotic Front,,
+ZMB,7187,Q2495149,United Democratic Alliance,,
+ZMB,7289,Q7887759,United Federal Party,,
+ZMB,4127,Q2495238,United Liberal Party,,
+ZMB,2334,Q1383387,United National Independence Party,UNIP,
+ZMB,2335,Q1781632,United Party for National Development,UPND,United Party for National Development
+ZMB,4125,Q145535,Zambian Democratic Congress,,
+ZMB,4128,Q1424763,Northern Rhodesian African National Congress,,Zambian African National Congress
+ZMB,4124,Q145517,Zambia Republic Party,,
+ZZB,5224,Q388064,Afro-Shirazi Party,,Chama cha Afro-Shirazi
+ZZB,8072,Q652091,Party of the Revolution,CCM,Chama cha Mapinduzi
+ZZB,8073,Q1094460,Civic United Front,CUF,
+ZZB,5225,Q3133539,Zanzibar and Pemba People's Party,,
+ZZB,5223,Q3133538,Zanzibar Nationalist Party,,
+ZWE,5346,Q48803171,Centre Party,,
+ZWE,7285,Q23777611,Confederate Party,,
+ZWE,6616,Q5473068,Forum Party,,
+ZWE,3558,Q2582118,Movement for Democratic Change,,
+ZWE,3560,Q15980776,Movement for Democratic Change – Ncube,,
+ZWE,3559,Q1146616,Movement for Democratic Change – Tsvangirai,,Movement for Democratic Change
+ZWE,7986,Q48798212,People's Democratic Party,,
+ZWE,7275,Q7315991,Responsible Government Association,RGA,
+ZWE,7277,Q7321052,Rhodesia Labour Party,,
+ZWE,7287,Q7321065,Rhodesian Action Party,,
+ZWE,5345,Q1185174,Rhodesian Front,RF,Rhodesian Front
+ZWE,7281,Q7321052,Rhodesia Labour Party,,
+ZWE,7282,Q7570405,Southern Rhodesia Liberal Party,,
+ZWE,6034,Q889447,United African National Council,UANC,
+ZWE,7280,Q7887759,United Federal Party,,
+ZWE,6440,Q7888292,United National Federal Party,,
+ZWE,8449,Q203427,Zimbabwe African National Union,,Zimbabwe African National Union
+ZWE,6032,Q8071965,Zimbabwe African National Union – Ndonga,ZANU/Ndonga,
+ZWE,3305,Q1910161,Zimbabwe African National Union – Patriotic Front,ZANU/PF,Zimbabwe African National Union – Patriotic Front
+ZWE,5344,Q203423,Zimbabwe African People's Union,ZAPU,Zimbabwe African People's Union

--- a/import/wikipedia/wikidata.py
+++ b/import/wikipedia/wikidata.py
@@ -1,0 +1,54 @@
+"""
+    Script for retrieving wikidata ids from partyfacts
+    outputs a csv file with the partyfacts ids and wikidata ids
+"""
+
+import pandas as pd
+import numpy as np
+import requests
+from urllib.parse import unquote
+from tqdm import tqdm
+
+
+# Load Data
+partyfacts = pd.read_csv("import/wikipedia/wikipedia.csv")
+
+
+# Pre-process wikipedia URL
+partyfacts['wiki_title'] = partyfacts.url.str.extract(r"wiki/(.*$)", expand=False)
+partyfacts['wiki_title'] = partyfacts.wiki_title.apply(unquote)
+partyfacts['wiki_server'] = partyfacts.url.apply(lambda x: x.split('/')[2])
+
+
+# Default Query Parameters
+params = {'action': 'query',
+          'prop': 'pageprops',
+          'ppprop': 'wikibase_item',
+          'redirects': 1,
+          'titles': '',
+          'format': 'json'}
+
+# Initialize empty column
+partyfacts['wikidata_id'] = ""
+
+# query wikidata for ID
+for index, row in tqdm(partyfacts.iterrows(), total=len(partyfacts), desc="Getting wikidata IDs"):
+    api = f"https://{row['wiki_server']}/w/api.php"
+    params['titles'] = row['wiki_title']
+    r = requests.get(api, params=params)
+    j = r.json()
+    try:
+        for val in j['query']['pages'].values():
+            wikidata_id = val['pageprops']['wikibase_item']
+            break
+    except:
+        wikidata_id = ""
+    partyfacts.at[index, 'wikidata_id'] = wikidata_id
+
+
+# prepare for export
+keep_cols = ['country', 'partyfacts_id', 'wikidata_id', 'name', 'name_short', 'name_native']
+partyfacts = partyfacts.loc[:,keep_cols]
+
+# save as csv
+partyfacts.reset_index(drop=True).to_csv('import/wikipedia/wikidata.csv', index = False)

--- a/import/wikipedia/wikidata.py
+++ b/import/wikipedia/wikidata.py
@@ -4,51 +4,61 @@
 """
 
 import pandas as pd
-import numpy as np
 import requests
 from urllib.parse import unquote
 from tqdm import tqdm
 
 
 # Load Data
-partyfacts = pd.read_csv("import/wikipedia/wikipedia.csv")
-
+pf_raw = pd.read_csv("wikipedia-data.csv")
+pf = pf_raw
 
 # Pre-process wikipedia URL
-partyfacts['wiki_title'] = partyfacts.url.str.extract(r"wiki/(.*$)", expand=False)
-partyfacts['wiki_title'] = partyfacts.wiki_title.apply(unquote)
-partyfacts['wiki_server'] = partyfacts.url.apply(lambda x: x.split('/')[2])
+pf["wiki_title"] = pf.url.str.extract(r"wiki/(.*$)", expand=False)
+pf["wiki_title"] = pf.wiki_title.apply(unquote)
+pf["wiki_server"] = pf.url.apply(lambda x: x.split("/")[2])
 
 
 # Default Query Parameters
-params = {'action': 'query',
-          'prop': 'pageprops',
-          'ppprop': 'wikibase_item',
-          'redirects': 1,
-          'titles': '',
-          'format': 'json'}
+params = {
+    "action": "query",
+    "prop": "pageprops",
+    "ppprop": "wikibase_item",
+    "redirects": 1,
+    "titles": "",
+    "format": "json",
+}
 
 # Initialize empty column
-partyfacts['wikidata_id'] = ""
+pf["wikidata_id"] = ""
 
 # query wikidata for ID
-for index, row in tqdm(partyfacts.iterrows(), total=len(partyfacts), desc="Getting wikidata IDs"):
+tqdm_iterrows = tqdm(pf.iterrows(), total=len(pf), desc="Getting wikidata IDs")
+
+for index, row in tqdm_iterrows:
     api = f"https://{row['wiki_server']}/w/api.php"
-    params['titles'] = row['wiki_title']
+    params["titles"] = row["wiki_title"]
     r = requests.get(api, params=params)
     j = r.json()
     try:
-        for val in j['query']['pages'].values():
-            wikidata_id = val['pageprops']['wikibase_item']
+        for val in j["query"]["pages"].values():
+            wikidata_id = val["pageprops"]["wikibase_item"]
             break
     except:
         wikidata_id = ""
-    partyfacts.at[index, 'wikidata_id'] = wikidata_id
+    pf.at[index, "wikidata_id"] = wikidata_id
 
 
 # prepare for export
-keep_cols = ['country', 'partyfacts_id', 'wikidata_id', 'name', 'name_short', 'name_native']
-partyfacts = partyfacts.loc[:,keep_cols]
+keep_cols = [
+    "country",
+    "partyfacts_id",
+    "wikidata_id",
+    "name",
+    "name_short",
+    "name_native",
+]
+pf = pf.loc[:, keep_cols]
 
 # save as csv
-partyfacts.reset_index(drop=True).to_csv('import/wikipedia/wikidata.csv', index = False)
+pf.reset_index(drop=True).to_csv("import/wikipedia/wikidata.csv", index=False)


### PR DESCRIPTION
I thought I could contribute to this great initiative by providing the Wikidata IDs for each party. You already collected the Wikipedia URLs, but the Wikidata IDs are even more useful.

Pull request includes csv with partyfacts ids mapped to wikidata ids as well as the script for retrieving the IDs from the Wikipedia URLs